### PR TITLE
Enable Manual Path Specification (#4)

### DIFF
--- a/lib/protox.ex
+++ b/lib/protox.ex
@@ -51,8 +51,6 @@ defmodule Protox do
         p -> Path.expand(p)
       end
 
-    IO.puts(path)
-
     files =
       case Keyword.drop(args, [:namespace, :path]) do
         schema: <<text::binary>> ->

--- a/lib/protox.ex
+++ b/lib/protox.ex
@@ -45,8 +45,16 @@ defmodule Protox do
         n -> n |> Code.eval_quoted() |> elem(0)
       end
 
+    path =
+      case Keyword.get(args, :path) do
+        nil -> nil
+        p -> Path.expand(p)
+      end
+
+    IO.puts(path)
+
     files =
-      case Keyword.delete(args, :namespace) do
+      case Keyword.drop(args, [:namespace, :path]) do
         schema: <<text::binary>> ->
           filename = "#{__CALLER__.module}_#{:sha |> :crypto.hash(text) |> Base.encode16()}.proto"
           filepath = [Mix.Project.build_path(), filename] |> Path.join() |> Path.expand()
@@ -57,7 +65,7 @@ defmodule Protox do
           files |> Enum.map(&Path.expand/1)
       end
 
-    {:ok, file_descriptor_set} = Protox.Protoc.run(files)
+    {:ok, file_descriptor_set} = Protox.Protoc.run(files, path)
     {enums, messages} = Protox.Parse.parse(file_descriptor_set, namespace)
 
     Protox.Define.define(enums, messages)

--- a/lib/protox/protoc.ex
+++ b/lib/protox/protoc.ex
@@ -1,12 +1,20 @@
 defmodule Protox.Protoc do
   @moduledoc false
 
-  def run([proto_file]) do
+  def run([proto_file], nil) do
     do_run([proto_file], ["-I", "#{proto_file |> Path.dirname() |> Path.expand()}"])
   end
 
-  def run(proto_files) do
+  def run([proto_file], path) do
+    do_run([proto_file], ["-I", path])
+  end
+
+  def run(proto_files, nil) do
     do_run(proto_files, ["-I", "#{common_directory_path(proto_files)}"])
+  end
+
+  def run(proto_files, path) do
+    do_run(proto_files, ["-I", path])
   end
 
   # -- Private

--- a/test/protox_test.exs
+++ b/test/protox_test.exs
@@ -55,6 +55,21 @@ defmodule ProtoxTest do
     ],
     namespace: Namespace
 
+  use Protox,
+    files: [
+      "./test/samples/prefix/foo.proto",
+      "./test/samples/prefix/bar/bar.proto",
+    ],
+    namespace: TestPrefix,
+    path: "./test/samples"
+
+  use Protox,
+    files: [
+      "./test/samples/prefix/baz.proto",
+    ],
+    namespace: TestPrefix,
+    path: "./test/samples"
+
   setup_all do
     {
       :ok,

--- a/test/samples/prefix/bar/bar.proto
+++ b/test/samples/prefix/bar/bar.proto
@@ -1,0 +1,7 @@
+syntax = "proto3";
+
+import "prefix/foo.proto";
+
+message Bar {
+  Foo foo = 1;
+}

--- a/test/samples/prefix/baz.proto
+++ b/test/samples/prefix/baz.proto
@@ -1,0 +1,3 @@
+syntax = "proto3";
+
+message Baz{}

--- a/test/samples/prefix/foo.proto
+++ b/test/samples/prefix/foo.proto
@@ -1,0 +1,3 @@
+syntax = "proto3";
+
+message Foo{}


### PR DESCRIPTION
I made it possible to manually specify the path that gets passed to `protoc`, as discussed in #4.

I tried to write some unit tests, but given that I don't know much about protocol buffers, or about the structure of your tests I gave up after a few attempts. I'm open to writing some unit tests at a later time if you can give me a few pointers though.