### PR TITLE
allow ability to construct file names at compile time

### DIFF
--- a/lib/protox.ex
+++ b/lib/protox.ex
@@ -37,10 +37,12 @@ defmodule Protox do
   '''
 
   defmacro __using__(args) do
+    {args, _} = Code.eval_quoted(args)
+
     namespace =
       case Keyword.get(args, :namespace) do
         nil -> nil
-        n -> n |> Code.eval_quoted() |> elem(0)
+        n -> n
       end
 
     path =

--- a/test/protox_test.exs
+++ b/test/protox_test.exs
@@ -42,7 +42,7 @@ defmodule ProtoxTest do
 
   use Protox,
     files: [
-      "./test/samples/proto2.proto",
+      Path.join(__DIR__, "test/samples/proto2.proto"),
       "./test/samples/proto2_extension.proto",
       "./test/samples/proto3.proto"
     ]
@@ -58,14 +58,14 @@ defmodule ProtoxTest do
   use Protox,
     files: [
       "./test/samples/prefix/foo.proto",
-      "./test/samples/prefix/bar/bar.proto",
+      "./test/samples/prefix/bar/bar.proto"
     ],
     namespace: TestPrefix,
-    path: "./test/samples"
+    path: Path.join(__DIR__, "test/samples")
 
   use Protox,
     files: [
-      "./test/samples/prefix/baz.proto",
+      "./test/samples/prefix/baz.proto"
     ],
     namespace: TestPrefix,
     path: "./test/samples"


### PR DESCRIPTION
The old version didn't allow cases like

```elixir
defmodule Foo do
  use Protox, files: [
   Path.join(__DIR__, "foo.proto")
  ]
end
```

Even though the path can be computed at compile time.