### PR TITLE
don't pass duplicate keys to defstruct

### DIFF
--- a/lib/protox/define.ex
+++ b/lib/protox/define.ex
@@ -151,15 +151,18 @@ defmodule Protox.Define do
 
   # Generate fields of the struct which is created for a message.
   defp make_struct_fields(fields, unknown_fields) do
-    for {_, _, name, kind, _} <- fields do
-      case kind do
-        :map -> {name, Macro.escape(%{})}
-        {:oneof, parent} -> {parent, nil}
-        :packed -> {name, []}
-        :unpacked -> {name, []}
-        {:default, default_value} -> {name, default_value}
-      end
-    end ++ [{unknown_fields, []}]
+    struct_fields =
+      for {_, _, name, kind, _} <- fields do
+        case kind do
+          :map -> {name, Macro.escape(%{})}
+          {:oneof, parent} -> {parent, nil}
+          :packed -> {name, []}
+          :unpacked -> {name, []}
+          {:default, default_value} -> {name, default_value}
+        end
+      end ++ [{unknown_fields, []}]
+
+    Enum.uniq(struct_fields)
   end
 
   # Get the list of fields that are marked as `required`.


### PR DESCRIPTION
When the struct keys are generated from field definitions, duplicate
keys are created if the proto uses oneof. This is because each oneof
option is stored as a separate field.
```elixir
[
  {5, :optional, :oneof_1_double, {:oneof, :oneof_1}, :double},
  {4, :optional, :oneof_1_int32, {:oneof, :oneof_1}, :int32},
]
```
This was not an issue as such, but newer version of elixir emits a
warning like below

warning: duplicate key :content found in struct
  (elixir 1.10.3) lib/kernel/utils.ex:119: Kernel.Utils.warn_on_duplicate_struct_key/1
  (elixir 1.10.3) lib/kernel/utils.ex:98: Kernel.Utils.defstruct/2
  lib/core/proto.ex:7: (module)
  (elixir 1.10.3) src/elixir_compiler.erl:75: :elixir_compiler.dispatch/4
  (elixir 1.10.3) src/elixir_compiler.erl:60:
  :elixir_compiler.compile/3

Using Enum.uniq will remove the duplicate key names if any introduced
by oneof.