### PR TITLE
Generate multiple files

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,6 +306,15 @@ The `--include-path` option is the same as the option described in section [Spec
 
 The generated file will be usable in any project as long as protox is declared in the dependancies (the generated file is not a standalone, it still needs function from the protox runtime).
 
+If you have large protobuf files, you can use the `--multiple-files` option to speed up real computation time of the generated files:
+
+```shell
+mkdir generated
+MIX_ENV=prod mix protox.generate --output-path=generated --include-path=. test/messages.proto test/samples/proto2.proto --multiple-files
+```
+
+Doing so, Elixir will be able to parallelize your app file compilations.
+
 ## Types mapping
 
 The following table shows how Protobuf types are mapped to Elixir's ones.

--- a/README.md
+++ b/README.md
@@ -310,7 +310,7 @@ If you have large protobuf files, you can use the `--multiple-files` option to s
 
 ```shell
 mkdir generated
-MIX_ENV=prod mix protox.generate --output-path=generated --include-path=. test/messages.proto test/samples/proto2.proto --multiple-files
+MIX_ENV=prod mix protox.generate --multiple-files --output-path=generated --include-path=. test/messages.proto test/samples/proto2.proto
 ```
 
 Doing so, Elixir will be able to parallelize your app file compilations.

--- a/lib/mix/tasks/protox/generate.ex
+++ b/lib/mix/tasks/protox/generate.ex
@@ -15,11 +15,15 @@ defmodule Mix.Tasks.Protox.Generate do
          multiple_files <- Keyword.get(options, :multiple_files, false) do
       files
       |> Protox.generate_module_code(output_path, multiple_files, include_path)
-      |> Enum.each(&Protox.generate_file/1)
+      |> Enum.each(&generate_file/1)
     else
       err ->
         IO.puts("Failed to generate code: #{inspect(err)}")
         :error
     end
+  end
+
+  defp generate_file(%Protox.FileContent{name: file_name, content: content}) do
+    File.write!(file_name, content)
   end
 end

--- a/lib/mix/tasks/protox/generate.ex
+++ b/lib/mix/tasks/protox/generate.ex
@@ -7,19 +7,19 @@ defmodule Mix.Tasks.Protox.Generate do
   @spec run(any) :: any
   def run(args) do
     with {options, files, []} <-
-           OptionParser.parse(args, strict: [output_path: :string, include_path: :string]),
+           OptionParser.parse(args,
+             strict: [output_path: :string, include_path: :string, multiple_files: :boolean]
+           ),
          {:ok, output_path} <- Keyword.fetch(options, :output_path),
-         include_path <- Keyword.get(options, :include_path) do
-      generate_code(files, output_path, include_path)
+         include_path <- Keyword.get(options, :include_path),
+         multiple_files <- Keyword.get(options, :multiple_files, false) do
+      files
+      |> Protox.generate_module_code(output_path, multiple_files, include_path)
+      |> Enum.each(&Protox.generate_file/1)
     else
       err ->
         IO.puts("Failed to generate code: #{inspect(err)}")
         :error
     end
-  end
-
-  defp generate_code(files, output_path, include_path) do
-    code = Protox.generate_code(files, include_path)
-    File.write!(output_path, code)
   end
 end

--- a/lib/protox.ex
+++ b/lib/protox.ex
@@ -118,7 +118,8 @@ defmodule Protox do
   defp generate_file_content(code),
     do: ["#", " credo:disable-for-this-file\n", Macro.to_string(code)]
 
-  def generate_file(%FileContent{name: file_name, content: content}), do: File.write!(file_name, content)
+  def generate_file(%FileContent{name: file_name, content: content}),
+    do: File.write!(file_name, content)
 
   defp make_external_resources(files) do
     Enum.map(files, fn file -> quote(do: @external_resource(unquote(file))) end)

--- a/lib/protox.ex
+++ b/lib/protox.ex
@@ -121,9 +121,6 @@ defmodule Protox do
   defp generate_file_content(code),
     do: ["#", " credo:disable-for-this-file\n", Macro.to_string(code)]
 
-  def generate_file(%FileContent{name: file_name, content: content}),
-    do: File.write!(file_name, content)
-
   defp make_external_resources(files) do
     Enum.map(files, fn file -> quote(do: @external_resource(unquote(file))) end)
   end

--- a/lib/protox.ex
+++ b/lib/protox.ex
@@ -68,7 +68,10 @@ defmodule Protox do
     end
   end
 
-  defmodule FileContent, do: defstruct([:name, :content])
+  defmodule FileContent do
+    @moduledoc false
+    defstruct([:name, :content])
+  end
 
   def generate_module_code(files, output_path, multiple_files, include_path \\ nil)
       when is_list(files) and is_binary(output_path) and is_boolean(multiple_files) do

--- a/lib/protox.ex
+++ b/lib/protox.ex
@@ -73,12 +73,12 @@ defmodule Protox do
     defstruct([:name, :content])
   end
 
-  def generate_module_code(files, output_path, multiple_files, include_path \\ nil)
+  def generate_module_code(files, output_path, multiple_files, include_path_or_nil)
       when is_list(files) and is_binary(output_path) and is_boolean(multiple_files) do
     path =
-      case include_path do
+      case include_path_or_nil do
         nil -> nil
-        _ -> Path.expand(include_path)
+        _ -> Path.expand(include_path_or_nil)
       end
 
     {:ok, file_descriptor_set} =


### PR DESCRIPTION
If you have a large protobuf file, `use Protox` can take a while, because it is not able to parallelize the loading.
Using `mix protox.generate`, Elixir can take a while too because it cannot parallelize the compilation of the unique generated file.
I propose to add a `--multiple-files` option to the `protox.generate` mix tasks, so that Elixir can parallelize the compilation of the different modules, and thus the real compilation time is decreased.