### PR TITLE
Allow namespaces through protox.generate

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,23 +31,27 @@ iex> {:ok, msg} = Msg.decode(binary)
 
 ## Table of contents
 
-- [Prerequisites](#prerequisites)
-- [Installation](#installation)
-- [Usage with a textual description](#usage-with-a-textual-description)
-- [Usage with files](#usage-with-files)
-- [Encode](#encode)
-- [Decode](#decode)
-- [Packages and namespaces](#packages-and--namespaces)
-- [Specify import path](#specify-import-path)
-- [Unknown fields](#unknown-fields)
-- [Unsupported features](#unsupported-features)
-- [Implementation choices](#implementation-choices)
-- [Generated code reference](#generated-code-reference)
-- [Files generation](#files-generation)
-- [Types mapping](#types-mapping)
-- [Conformance](#conformance)
-- [Benchmarks](#benchmarks)
-- [Credits](#credits)
+- [Protox](#protox)
+  - [Table of contents](#table-of-contents)
+  - [Prerequisites](#prerequisites)
+  - [Installation](#installation)
+  - [Usage with a textual description](#usage-with-a-textual-description)
+  - [Usage with files](#usage-with-files)
+  - [Encode](#encode)
+  - [Decode](#decode)
+  - [Packages and  namespaces](#packages-and--namespaces)
+    - [Packages](#packages)
+    - [Prepend namespaces](#prepend-namespaces)
+  - [Specify import path](#specify-import-path)
+  - [Unknown fields](#unknown-fields)
+  - [Unsupported features](#unsupported-features)
+  - [Implementation choices](#implementation-choices)
+  - [Generated code reference](#generated-code-reference)
+  - [Files generation](#files-generation)
+  - [Types mapping](#types-mapping)
+  - [Conformance](#conformance)
+  - [Benchmarks](#benchmarks)
+  - [Credits](#credits)
 
 ## Prerequisites
 
@@ -382,6 +386,8 @@ MIX_ENV=prod mix protox.generate --multiple-files --output-path=generated --incl
 ```
 
 Doing so, Elixir will be able to parallelize the compilation of generated modules.
+
+It is also possible to prepend a namespace to all generated modules using the `--namespace` option. More information is available in section [Prepend namespaces](#prepend-namespaces).
 
 Finally, you can pass the option `--keep-unknown-fields=false` to remove support of unknown fields. See [this section](#unknown-fields) for more information.
 

--- a/lib/mix/tasks/protox/generate.ex
+++ b/lib/mix/tasks/protox/generate.ex
@@ -8,6 +8,8 @@ defmodule Mix.Tasks.Protox.Generate do
   The generated file will be usable in any project as long as protox is declared
   in the dependencies (the generated file still needs functions from the protox runtime).
 
+  You can use the `--namespace` option to prepend a namespace to all generated modules.
+
   If you have large protobuf files, you can use the `--multiple-files` option to generate
   one file per module.
 
@@ -26,16 +28,18 @@ defmodule Mix.Tasks.Protox.Generate do
              strict: [
                output_path: :string,
                include_path: :string,
+               namespace: :string,
                multiple_files: :boolean,
                keep_unknown_fields: :boolean
              ]
            ),
          {:ok, output_path} <- Keyword.fetch(opts, :output_path) do
       {include_path, opts} = Keyword.pop(opts, :include_path)
+      {namespace, opts} = Keyword.pop(opts, :namespace)
       {multiple_files, opts} = Keyword.pop(opts, :multiple_files, false)
 
       files
-      |> Protox.generate_module_code(output_path, multiple_files, include_path, opts)
+      |> Protox.generate_module_code(output_path, multiple_files, include_path, namespace, opts)
       |> Enum.each(&generate_file/1)
     else
       err ->

--- a/lib/protox.ex
+++ b/lib/protox.ex
@@ -80,7 +80,14 @@ defmodule Protox do
     defstruct([:name, :content])
   end
 
-  def generate_module_code(files, output_path, multiple_files, include_path_or_nil, opts \\ [])
+  def generate_module_code(
+        files,
+        output_path,
+        multiple_files,
+        include_path_or_nil,
+        namespace_or_nil \\ nil,
+        opts \\ []
+      )
       when is_list(files) and is_binary(output_path) and is_boolean(multiple_files) do
     path =
       case include_path_or_nil do
@@ -93,7 +100,7 @@ defmodule Protox do
       |> Enum.map(&Path.expand/1)
       |> Protox.Protoc.run(path)
 
-    {enums, messages} = Protox.Parse.parse(file_descriptor_set, nil)
+    {enums, messages} = Protox.Parse.parse(file_descriptor_set, namespace_or_nil)
 
     code = quote do: unquote(Protox.Define.define(enums, messages, opts))
 

--- a/test/code_generation_test.exs
+++ b/test/code_generation_test.exs
@@ -63,6 +63,14 @@ defmodule Protox.CodeGenerationTest do
     launch(".", ["--multiple-files", "--keep-unknown-fields=false"])
   end
 
+  test "Generate single file, with namespace" do
+    launch("single_with_namespace.ex", ["--namespace=Namespace"])
+  end
+
+  test "Generate multiple files, with namespace" do
+    launch(".", ["--multiple-files", "--namespace=Namespace"])
+  end
+
   test "Mix task generates a file that can be compiled" do
     tmp_dir = System.tmp_dir!()
     tmp_file = Path.join(tmp_dir, "file.ex")


### PR DESCRIPTION
Extend `protox.generate` so namespaces can be provided through the CLI.

- `mix protox.generate --namespace=Namespace`
- Includes some simple tests to confirm the new CLI option works.
- Update README