### PR TITLE
Implement Proto3 Field Presence

### DIFF
--- a/README.md
+++ b/README.md
@@ -320,7 +320,7 @@ Note that protox will still correctly parse unknown fields, they just won't be a
         ```
         It means that if you need to know if a field has been set by the sender, you just have to test if its value is `nil` or not.
 
-    * For Protobuf 3, unset fields are mapped to their [default values](https://developers.google.com/protocol-buffers/docs/proto3#default). However, if you use the `optional` keyword, then unset fields will be mapped to `nil`:
+    * For Protobuf 3, unset fields are mapped to their [default values](https://developers.google.com/protocol-buffers/docs/proto3#default). However, if you use the `optional` keyword (available in protoc version 3.15 and higher), then unset fields will be mapped to `nil`:
         ```elixir
         defmodule Bar do
           use Protox,

--- a/README.md
+++ b/README.md
@@ -320,7 +320,7 @@ Note that protox will still correctly parse unknown fields, they just won't be a
         ```
         It means that if you need to know if a field has been set by the sender, you just have to test if its value is `nil` or not.
 
-    * For Protobuf 3, unset optional fields are mapped to their default values, as mandated by the [Protobuf spec](https://developers.google.com/protocol-buffers/docs/proto3#default):
+    * For Protobuf 3, unset fields are mapped to their [default values](https://developers.google.com/protocol-buffers/docs/proto3#default). However, if you use the `optional` keyword, then unset fields will be mapped to `nil`:
         ```elixir
         defmodule Bar do
           use Protox,
@@ -329,6 +329,7 @@ Note that protox will still correctly parse unknown fields, they just won't be a
 
             message Foo {
               int32 a = 1;
+              optional int32 b = 2;
             }
           """
         end
@@ -339,6 +340,11 @@ Note that protox will still correctly parse unknown fields, they just won't be a
         iex> %Foo{}.a
         0
 
+        iex> Foo.default(:b)
+        {:error, :no_default_value}
+
+        iex> %Foo{}.b
+        nil
         ```
 
 * Messages and enums names: names are converted using the [`Macro.camelize/1`](https://hexdocs.pm/elixir/Macro.html#camelize/1) function.

--- a/lib/protox/define_message.ex
+++ b/lib/protox/define_message.ex
@@ -118,10 +118,10 @@ defmodule Protox.DefineMessage do
   # Generate fields of the struct which is created for a message.
   defp make_struct_fields(fields, syntax, unknown_fields, keep_unknown_fields) do
     struct_fields =
-      for {_, _, name, kind, _} <- fields do
+      for {_, label, name, kind, _} <- fields do
         case kind do
           :map -> {name, Macro.escape(%{})}
-          {:oneof, parent} -> {parent, nil}
+          {:oneof, parent} -> make_oneof_field(label, name, parent)
           :packed -> {name, []}
           :unpacked -> {name, []}
           {:default, _} when syntax == :proto2 -> {name, nil}
@@ -137,6 +137,9 @@ defmodule Protox.DefineMessage do
 
     Enum.uniq(struct_fields)
   end
+
+  defp make_oneof_field(:proto3_optional, name, _), do: {name, nil}
+  defp make_oneof_field(_, _, parent), do: {parent, nil}
 
   # Get the list of fields that are marked as `required`.
   defp make_required_fields(fields) do

--- a/lib/protox/defs.ex
+++ b/lib/protox/defs.ex
@@ -11,7 +11,11 @@ defmodule Protox.Defs do
       end)
 
     {
-      oneofs |> Enum.group_by(fn {_, _, _, {:oneof, parent}, _} -> parent end) |> Map.to_list(),
+      oneofs
+      |> Enum.group_by(fn {_, label, name, {:oneof, parent}, _} ->
+        oneof_groupby(label, name, parent)
+      end)
+      |> Map.to_list(),
       fields
     }
   end
@@ -22,4 +26,7 @@ defmodule Protox.Defs do
       _ -> false
     end)
   end
+
+  defp oneof_groupby(:proto3_optional, name, _parent), do: name
+  defp oneof_groupby(_, _, parent), do: parent
 end

--- a/lib/protox/descriptor.ex
+++ b/lib/protox/descriptor.ex
@@ -106,7 +106,8 @@ defmodule Protox.Descriptor do
           {2, :none, :extendee, {:default, nil}, :string},
           {7, :none, :default_value, {:default, nil}, :string},
           {9, :none, :oneof_index, {:default, nil}, :int32},
-          {8, :none, :options, {:default, nil}, {:message, Protox.Google.Protobuf.FieldOptions}}
+          {8, :none, :options, {:default, nil}, {:message, Protox.Google.Protobuf.FieldOptions}},
+          {17, :none, :proto3_optional, {:default, false}, :bool}
         ]
       },
       {

--- a/lib/protox/parse.ex
+++ b/lib/protox/parse.ex
@@ -210,7 +210,7 @@ defmodule Protox.Parse do
         nil ->
           type = get_type(descriptor)
           kind = get_kind(syntax, upper, descriptor)
-          {descriptor.label, kind, type}
+          {field_label(descriptor), kind, type}
 
         map_type ->
           {nil, :map, map_type}
@@ -223,6 +223,9 @@ defmodule Protox.Parse do
       Map.update!(msgs, msg_name, fn {syntax, fields} -> {syntax, [field | fields]} end)
     }
   end
+
+  defp field_label(%{proto3_optional: true}), do: :proto3_optional
+  defp field_label(%{label: label}), do: label
 
   defp map_entry(nil, _, _), do: nil
 

--- a/test/example_test.exs
+++ b/test/example_test.exs
@@ -21,6 +21,9 @@ defmodule ExampleTest do
         FooOrBar g = 7;
         repeated int32 h = 8;
         map<string, int32> i = 9;
+        optional bool j = 10;
+        optional bool k = 11;
+        optional bool l = 12;
       }
 
       message Envelope {
@@ -45,7 +48,9 @@ defmodule ExampleTest do
            f: true,
            g: :FOO,
            h: [1, 2, 3],
-           i: %{"foo" => 42, "bar" => 33}
+           i: %{"foo" => 42, "bar" => 33},
+           k: false,
+           l: true
          }}
     }
 
@@ -55,7 +60,9 @@ defmodule ExampleTest do
     }
 
     encoded_sub_msg = sub_msg |> Envelope.encode!() |> :binary.list_to_bin()
-    assert Envelope.decode!(encoded_sub_msg) == sub_msg
+    decoded_sub_msg = Envelope.decode!(encoded_sub_msg)
+    assert decoded_sub_msg == sub_msg
+    assert %{envelope: {:sub_msg, %SubMsg{j: nil, k: false, l: true}}} = decoded_sub_msg
 
     encoded_str = str |> Envelope.encode!() |> :binary.list_to_bin()
     assert Envelope.decode!(encoded_str) == str


### PR DESCRIPTION
Closes #49

Rather than generating functions like `has_#{field_name}` to track presence, as suggested [in this document](https://github.com/protocolbuffers/protobuf/blob/master/docs/implementing_proto3_presence.md), I am simply using the value `nil` in the case where an optional field was not present. I think this should be alright, because in normal case, where fields are not optional and therefore set to the [default value](https://github.com/protocolbuffers/protobuf/blob/master/docs/implementing_proto3_presence.md)  according to their type, none of them use `nil`. 

The strategy I used was to change the field label to `:proto3_optional` when proto3_optional == true in the `%Protox.Google.Protobuf.FieldDescriptorProto{}` as it seemed to be the least intrusive change to make.

I also considered adding a new field to the 5 element tuple that is used internally to represent fields, rather than reusing the label field, but I think that would have been more intrusive.

Have you considered refactoring the 5-tuple to a struct? It could possibly be more future proof and easier to pass around than the tuple.

I tried to follow the instructions in the README to run the conformance tests, but it seems something has changed so I was not able to run them yet, but otherwise the new code I added is covered by my additions to the `ExampleTest`. I'm happy to add more tests if you'd like. EDIT: It appears that the CI runs these for you 😄 

Looking forward to hearing your thoughts!