### PR TITLE
allow multiple import paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ It's useful to make the generated code appear as being part of your code structu
 
 ## Specify import path
 
-An import path can be specified using the `path:` option that specifies the directory in which to search for import:
+An import path can be specified using the `path:` or `paths:` option that specifies the directory/ies in which to search for import:
 
 ```elixir
 defmodule Baz do
@@ -220,6 +220,23 @@ defmodule Baz do
       "./defs/prefix/bar/bar.proto",
     ],
     path: "./defs"
+end
+```
+
+or if multiple search paths are needed:
+
+```elixir
+defmodule Baz do
+  use Protox,
+    files: [
+      "./defs1/prefix/foo.proto",
+      "./defs1/prefix/bar.proto",
+      "./defs2/prefix/baz/baz.proto"
+    ],
+    paths: [
+      "./defs1",
+      "./defs2"
+    ]
 end
 ```
 
@@ -384,7 +401,7 @@ It's also possible to generate a file that will contain all code corresponding t
 MIX_ENV=prod mix protox.generate --output-path=/path/to/message.ex --include-path=. test/messages.proto test/samples/proto2.proto
 ```
 
-The `--include-path` option is the same as the option described in section [Specify import path](#specify-import-path).
+The `--include-path` option is the same as the option described in section [Specify import path](#specify-import-path). If multiple include paths are needed, simply add more `--include-path` options.
 
 The generated file will be usable in any project as long as protox is declared in the dependencies (the generated file still needs functions from the protox runtime).
 

--- a/lib/mix/tasks/protox/generate.ex
+++ b/lib/mix/tasks/protox/generate.ex
@@ -27,14 +27,14 @@ defmodule Mix.Tasks.Protox.Generate do
            OptionParser.parse(args,
              strict: [
                output_path: :string,
-               include_path: :string,
+               include_path: :keep,
                namespace: :string,
                multiple_files: :boolean,
                keep_unknown_fields: :boolean
              ]
            ),
          {:ok, output_path} <- Keyword.fetch(opts, :output_path) do
-      {include_path, opts} = Keyword.pop(opts, :include_path)
+      {include_paths, opts} = Keyword.pop(opts, :include_path)
       {namespace, opts} = Keyword.pop(opts, :namespace)
       {multiple_files, opts} = Keyword.pop(opts, :multiple_files, false)
 
@@ -42,7 +42,7 @@ defmodule Mix.Tasks.Protox.Generate do
       |> Protox.generate_module_code(
         Path.expand(output_path),
         multiple_files,
-        include_path,
+        include_paths,
         namespace,
         opts
       )

--- a/lib/protox/protoc.ex
+++ b/lib/protox/protoc.ex
@@ -5,19 +5,22 @@ defmodule Protox.Protoc do
     do_run([proto_file], ["-I", "#{proto_file |> Path.dirname() |> Path.expand()}"])
   end
 
-  def run([proto_file], path) do
-    do_run([proto_file], ["-I", path])
+  def run([proto_file], paths) do
+    do_run([proto_file], paths_to_protoc_args(paths))
   end
 
   def run(proto_files, nil) do
     do_run(proto_files, ["-I", "#{common_directory_path(proto_files)}"])
   end
 
-  def run(proto_files, path) do
-    do_run(proto_files, ["-I", path])
+  def run(proto_files, paths) do
+    do_run(proto_files, paths_to_protoc_args(paths))
   end
 
   # -- Private
+  defp paths_to_protoc_args(paths) do
+    paths |> Enum.map(&["-I", &1]) |> Enum.concat()
+  end
 
   defp do_run(proto_files, args) do
     outfile_name = "protox_#{random_string()}"

--- a/test/protox_test.exs
+++ b/test/protox_test.exs
@@ -284,7 +284,7 @@ defmodule ProtoxTest do
     generated_file_name = "generated_code.ex"
 
     assert [%Protox.FileContent{name: ^generated_file_name, content: content}] =
-             Protox.generate_module_code([file], generated_file_name, false, "./test/samples")
+             Protox.generate_module_code([file], generated_file_name, false, ["./test/samples"])
 
     tmp_dir = System.tmp_dir!()
     tmp_file = Path.join(tmp_dir, generated_file_name)
@@ -305,7 +305,7 @@ defmodule ProtoxTest do
                [file],
                generated_file_name,
                false,
-               "./test/samples",
+               ["./test/samples"],
                "Namespace"
              )
 
@@ -326,7 +326,7 @@ defmodule ProtoxTest do
     assert [
              %Protox.FileContent{name: "generated_code/elixir_bar.ex", content: bar_content},
              %Protox.FileContent{name: "generated_code/elixir_foo.ex", content: foo_content}
-           ] = Protox.generate_module_code([file], generated_path_name, true, "./test/samples")
+           ] = Protox.generate_module_code([file], generated_path_name, true, ["./test/samples"])
 
     tmp_dir = System.tmp_dir!()
     bar_tmp_file = Path.join(tmp_dir, "bar.ex")
@@ -360,7 +360,7 @@ defmodule ProtoxTest do
                [file],
                generated_path_name,
                true,
-               "./test/samples",
+               ["./test/samples"],
                "Namespace"
              )
 


### PR DESCRIPTION
This PR introduces the possibility of specifying multiple `import paths`:
- for `use Protoc` modules, simply use `paths: ["./a", "./b", ...]` instead of `path: "./foo"`
- for `mix protox.generate` simply specify `--include-path` multiple times

For the task I'm responsible for at work, I create packages based on almost unconstrained `protobuf` definitions, and sometimes I have the need to compile a bunch of protobuf files that depends on each other and requires multiple `-I` paths on `protoc` invocation.