### PR TITLE
Update generate.ex - fetch all include_path

### DIFF
--- a/lib/mix/tasks/protox/generate.ex
+++ b/lib/mix/tasks/protox/generate.ex
@@ -34,7 +34,7 @@ defmodule Mix.Tasks.Protox.Generate do
              ]
            ),
          {:ok, output_path} <- Keyword.fetch(opts, :output_path) do
-      {include_paths, opts} = Keyword.pop_values(opts, :include_path)
+      {include_paths, opts} = pop_values(opts, :include_path)
       {namespace, opts} = Keyword.pop(opts, :namespace)
       {multiple_files, opts} = Keyword.pop(opts, :multiple_files, false)
 
@@ -56,5 +56,16 @@ defmodule Mix.Tasks.Protox.Generate do
 
   defp generate_file(%Protox.FileContent{name: file_name, content: content}) do
     File.write!(file_name, content)
+  end
+
+  # Custom implementation as Keyword.pop_values/2 is only available since Elixir 1.10
+  defp pop_values(opts, key) do
+    {values, new_opts} =
+      Enum.reduce(opts, {[], []}, fn
+        {^key, value}, {values, new_opts} -> {[value | values], new_opts}
+        {key, value}, {values, new_opts} -> {values, [{key, value} | new_opts]}
+      end)
+
+    {Enum.reverse(values), Enum.reverse(new_opts)}
   end
 end

--- a/lib/mix/tasks/protox/generate.ex
+++ b/lib/mix/tasks/protox/generate.ex
@@ -34,7 +34,7 @@ defmodule Mix.Tasks.Protox.Generate do
              ]
            ),
          {:ok, output_path} <- Keyword.fetch(opts, :output_path) do
-      {include_paths, opts} = Keyword.pop(opts, :include_path)
+      {include_paths, opts} = Keyword.pop_values(opts, :include_path)
       {namespace, opts} = Keyword.pop(opts, :namespace)
       {multiple_files, opts} = Keyword.pop(opts, :multiple_files, false)
 

--- a/lib/protox.ex
+++ b/lib/protox.ex
@@ -91,15 +91,15 @@ defmodule Protox do
         files,
         output_path,
         multiple_files,
-        include_paths_or_nil,
+        include_paths,
         namespace_or_nil \\ nil,
         opts \\ []
       )
       when is_list(files) and is_binary(output_path) and is_boolean(multiple_files) do
     paths =
-      case include_paths_or_nil do
-        nil -> nil
-        _ -> Enum.map(include_paths_or_nil, &Path.expand/1)
+      case include_paths do
+        [] -> nil
+        _ -> Enum.map(include_paths, &Path.expand/1)
       end
 
     {:ok, file_descriptor_set} =


### PR DESCRIPTION
When multiple instances of `include_path` are defined, only the first would be accessed by `Keyword.pop/2`, however `Keyword.pop_values/2` will retrieve all values as a list which is the expected datatype (or nil) by `generate_module_code/6`.