### PR TITLE
Use `import Bitwise` instead of `use Bitwise`

### DIFF
--- a/lib/protox/decode.ex
+++ b/lib/protox/decode.ex
@@ -2,7 +2,7 @@ defmodule Protox.Decode do
   @moduledoc false
   # Helpers decoding functions that will be used by the generated code.
 
-  use Bitwise
+  import Bitwise
 
   use Protox.{
     Float,

--- a/lib/protox/encode.ex
+++ b/lib/protox/encode.ex
@@ -4,7 +4,7 @@ defmodule Protox.Encode do
   """
 
   import Protox.Guards
-  use Bitwise
+  import Bitwise
 
   use Protox.{
     Float,

--- a/lib/protox/varint.ex
+++ b/lib/protox/varint.ex
@@ -2,7 +2,7 @@ defmodule Protox.Varint do
   @moduledoc false
   # Internal. Implement LEB128 compression.
 
-  use Bitwise
+  import Bitwise
 
   @spec encode(integer) :: iodata
   def encode(v) when v < 128, do: <<v>>

--- a/lib/protox/zigzag.ex
+++ b/lib/protox/zigzag.ex
@@ -2,7 +2,7 @@ defmodule Protox.Zigzag do
   @moduledoc false
   # Internal. Map integers to positive integers as LEB128 can only work on the latters.
 
-  use Bitwise
+  import Bitwise
 
   @spec encode(integer) :: non_neg_integer
   def encode(v) when v >= 0, do: v * 2


### PR DESCRIPTION
Fixes deprecation warnings in Elixir >= `1.14`