### PR TITLE
Correct type spec for encode/1 enum module

### DIFF
--- a/lib/protox/define_enum.ex
+++ b/lib/protox/define_enum.ex
@@ -16,7 +16,7 @@ defmodule Protox.DefineEnum do
 
           unquote(default_fun)
 
-          @spec encode(atom()) :: integer() | atom()
+          @spec encode(atom() | String.t()) :: integer() | atom()
           unquote(encode_constants_funs)
           def encode(x), do: x
 


### PR DESCRIPTION
When generating enum module with `mix protox.generate`, the encode/1 will generated as:

   ```elixir
   def encode(:OK) do
     0
   end

   def encode("OK") do
     0
   end
   ```

The function accept both atom and string. But the typespec tells it accept only atom:

   ```elixir
   @spec encode(atom()) :: integer() | atom()
   ```

This change fixes by add type String.t() into the spec in DefineEnum module.

NOTE: The code above generated from googleapis/google/rpc/code.proto.