### PR TITLE
Raise for invalid strings

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,5 @@
 # [Unreleased]
-  - Raise DecodingError for invalid strings
+  - Raise DecodingError and EncodingError for invalid strings
 
 # 1.7.2
   - Fix typespec of enum encode function (thanks to https://github.com/wingyplus)

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+# [Unreleased]
+  - Raise DecodingError for invalid strings
+
 # 1.7.2
   - Fix typespec of enum encode function (thanks to https://github.com/wingyplus)
 

--- a/lib/protox/decode.ex
+++ b/lib/protox/decode.ex
@@ -2,9 +2,6 @@ defmodule Protox.Decode do
   @moduledoc false
   # Helpers decoding functions that will be used by the generated code.
 
-  # Reference: https://protobuf.dev/programming-guides/proto3/#scalar
-  @max_string_size Bitwise.<<<(1, 32)
-
   import Bitwise
 
   use Protox.{
@@ -155,10 +152,15 @@ defmodule Protox.Decode do
   end
 
   def validate_string(bytes) do
-    if String.valid?(bytes) and byte_size(bytes) <= @max_string_size do
-      bytes
-    else
-      raise Protox.DecodingError.new(bytes, "string is not valid UTF-8")
+    case Protox.String.validate(bytes) do
+      :ok ->
+        bytes
+
+      {:error, :invalid_utf8} ->
+        raise Protox.DecodingError.new(bytes, "string is not valid UTF-8")
+
+      {:error, :too_large} ->
+        raise Protox.DecodingError.new(bytes, "string is too large")
     end
   end
 

--- a/lib/protox/decode.ex
+++ b/lib/protox/decode.ex
@@ -2,6 +2,9 @@ defmodule Protox.Decode do
   @moduledoc false
   # Helpers decoding functions that will be used by the generated code.
 
+  # Reference: https://protobuf.dev/programming-guides/proto3/#scalar
+  @max_string_size Bitwise.<<<(1, 32)
+
   import Bitwise
 
   use Protox.{
@@ -149,6 +152,14 @@ defmodule Protox.Decode do
     {value, rest} = Varint.decode(bytes)
     <<res::signed-native-64>> = <<value::signed-native-64>>
     {res, rest}
+  end
+
+  def validate_string(bytes) do
+    if String.valid?(bytes) and byte_size(bytes) <= @max_string_size do
+      bytes
+    else
+      raise Protox.DecodingError.new(bytes, "string is not valid UTF-8")
+    end
   end
 
   def parse_repeated_bool(acc, <<>>), do: Enum.reverse(acc)

--- a/lib/protox/define_decoder.ex
+++ b/lib/protox/define_decoder.ex
@@ -274,7 +274,7 @@ defmodule Protox.DefineDecoder do
     # Thus, it's useless to wrap in a list the result of the decoding as it means
     # we're using a parse_repeated_* function that always returns a list.
     update_field =
-      if field.type == :string or field.type == :bytes do
+      if field.type == :bytes do
         make_update_field(vars.delimited, field, vars, _wrap_value = !single_generated)
       else
         parse_delimited = make_parse_delimited(vars.delimited, field.type)
@@ -392,7 +392,7 @@ defmodule Protox.DefineDecoder do
   end
 
   defp make_parse_delimited(bytes_var, :string) do
-    quote(do: unquote(bytes_var))
+    quote(do: Protox.Decode.validate_string(unquote(bytes_var)))
   end
 
   defp make_parse_delimited(bytes_var, {:enum, mod}) do

--- a/lib/protox/encode.ex
+++ b/lib/protox/encode.ex
@@ -151,7 +151,16 @@ defmodule Protox.Encode do
   @doc false
   @spec encode_string(String.t()) :: iodata
   def encode_string(value) do
-    [Varint.encode(byte_size(value)), value]
+    case Protox.String.validate(value) do
+      :ok ->
+        [Varint.encode(byte_size(value)), value]
+
+      {:error, :invalid_utf8} ->
+        raise ArgumentError, message: "String is not valid UTF-8"
+
+      {:error, :too_large} ->
+        raise ArgumentError, message: "String is too large"
+    end
   end
 
   @doc false

--- a/lib/protox/string.ex
+++ b/lib/protox/string.ex
@@ -1,0 +1,23 @@
+defmodule Protox.String do
+  @moduledoc false
+
+  if Mix.env() == :test do
+    @max_size Bitwise.<<<(1, 20)
+  else
+    # Reference: https://protobuf.dev/programming-guides/proto3/#scalar
+    @max_size Bitwise.<<<(1, 32)
+  end
+
+  def validate(bytes) do
+    cond do
+      not String.valid?(bytes) ->
+        {:error, :invalid_utf8}
+
+      byte_size(bytes) > @max_size ->
+        {:error, :too_large}
+
+      true ->
+        :ok
+    end
+  end
+end

--- a/lib/protox/string.ex
+++ b/lib/protox/string.ex
@@ -3,6 +3,7 @@ defmodule Protox.String do
 
   if Mix.env() == :test do
     @max_size Bitwise.<<<(1, 20)
+    def max_size, do: @max_size
   else
     # Reference: https://protobuf.dev/programming-guides/proto3/#scalar
     @max_size Bitwise.<<<(1, 32)

--- a/test/protox/decode_test.exs
+++ b/test/protox/decode_test.exs
@@ -924,6 +924,26 @@ defmodule Protox.DecodeTest do
       "Optional sub message set to nim",
       <<>>,
       %OptionalUpperMsg{sub: nil}
+    },
+    {
+      "Empty string",
+      <<10, 0>>,
+      %StringsAreUTF8{}
+    },
+    {
+      "Non-ascii string",
+      <<10, 39, "hello, 漢字, 💻, 🏁, working fine">>,
+      %StringsAreUTF8{a: "hello, 漢字, 💻, 🏁, working fine"}
+    },
+    {
+      "Empty repeated string (first occurence)",
+      <<18, 0, 18, 5, "hello">>,
+      %StringsAreUTF8{b: ["", "hello"]}
+    },
+    {
+      "Empty repeated string (second occurence)",
+      <<18, 5, "hello", 18, 0>>,
+      %StringsAreUTF8{b: ["hello", ""]}
     }
   ]
 
@@ -1007,6 +1027,80 @@ defmodule Protox.DecodeTest do
       <<8, 128>>,
       Empty,
       Protox.DecodingError
+    },
+    {
+      "invalid string (incomplete prefix)",
+      # We set field nr 1 to the length delimited value <<128, ?a>>
+      <<10, 2, 128, ?a>>,
+      StringsAreUTF8,
+      {Protox.DecodingError,
+       quote do
+         ~r/string is not valid UTF-8/
+       end}
+    },
+    {
+      "invalid string (incomplete suffix)",
+      # We set field nr 1 to the length delimited value <<?a, 128>>
+      <<10, 2, ?a, 128>>,
+      StringsAreUTF8,
+      {Protox.DecodingError,
+       quote do
+         ~r/string is not valid UTF-8/
+       end}
+    },
+    {
+      "invalid string (incomplete infix)",
+      # We set field nr 1 to the length delimited value <<?a, 255, ?b>>
+      <<10, 3, ?a, 255, ?b>>,
+      StringsAreUTF8,
+      {Protox.DecodingError,
+       quote do
+         ~r/string is not valid UTF-8/
+       end}
+    },
+    {
+      "invalid string (random data)",
+      # We set field nr 1 to length delimited 64 bytes of random data
+      <<10, 64>> <> :crypto.strong_rand_bytes(64),
+      StringsAreUTF8,
+      {Protox.DecodingError,
+       quote do
+         ~r/string is not valid UTF-8/
+       end}
+    },
+    {
+      "invalid repeated string (1st occurence)",
+      # We set first occurence of field nr 2 to the length delimited value <<128>>
+      <<
+        18,
+        2,
+        128,
+        18,
+        1,
+        "hello"
+      >>,
+      StringsAreUTF8,
+      {Protox.DecodingError,
+       quote do
+         ~r/string is not valid UTF-8/
+       end}
+    },
+    {
+      "invalid repeated string (2nd occurance)",
+      # We set second occurence of field nr 2 to the length delimited value <<128>>
+      <<
+        18,
+        5,
+        "hello",
+        18,
+        1,
+        128
+      >>,
+      StringsAreUTF8,
+      {Protox.DecodingError,
+       quote do
+         ~r/string is not valid UTF-8/
+       end}
     }
   ]
 
@@ -1024,8 +1118,16 @@ defmodule Protox.DecodeTest do
       bytes = unquote(bytes)
       mod = unquote(mod)
 
-      assert_raise unquote(exception), fn ->
-        Protox.decode!(bytes, mod)
+      case unquote(exception) do
+        {exception_mod, exception_msg} ->
+          assert_raise exception_mod, exception_msg, fn ->
+            Protox.decode!(bytes, mod)
+          end
+
+        exception_mod ->
+          assert_raise exception_mod, fn ->
+            Protox.decode!(bytes, mod)
+          end
       end
     end
   end

--- a/test/protox/decode_test.exs
+++ b/test/protox/decode_test.exs
@@ -6,8 +6,10 @@ end
 defmodule Protox.DecodeTest do
   use ExUnit.Case
 
-  @max_valid_string_size Protox.String.max_size()
-  @min_invalid_string_size Protox.String.max_size() + 1
+  max_valid_string_size = Protox.String.max_size()
+
+  varint_with_max_valid_string_size =
+    Protox.Varint.encode(max_valid_string_size) |> IO.iodata_to_binary()
 
   @success_tests [
     {
@@ -950,10 +952,16 @@ defmodule Protox.DecodeTest do
     },
     {
       "Largest valid string (tests-specific limit of 1 MiB)",
-      <<10, 128, 128, 64>> <> <<0::integer-size(@max_valid_string_size)-unit(8)>>,
-      %StringsAreUTF8{a: <<0::integer-size(@max_valid_string_size)-unit(8)>>}
+      <<10>> <>
+        varint_with_max_valid_string_size <> <<0::integer-size(max_valid_string_size)-unit(8)>>,
+      %StringsAreUTF8{a: <<0::integer-size(max_valid_string_size)-unit(8)>>}
     }
   ]
+
+  min_invalid_string_size = max_valid_string_size + 1
+
+  varint_with_min_invalid_string_size =
+    Protox.Varint.encode(min_invalid_string_size) |> IO.iodata_to_binary()
 
   @failure_tests [
     {
@@ -1112,7 +1120,9 @@ defmodule Protox.DecodeTest do
     },
     {
       "too large a string (tests-specific limit of 1 MiB)",
-      <<10, 129, 128, 64>> <> <<0::integer-size(@min_invalid_string_size)-unit(8)>>,
+      <<10>> <>
+        varint_with_min_invalid_string_size <>
+        <<0::integer-size(min_invalid_string_size)-unit(8)>>,
       StringsAreUTF8,
       {Protox.DecodingError,
        quote do

--- a/test/protox/decode_test.exs
+++ b/test/protox/decode_test.exs
@@ -947,8 +947,8 @@ defmodule Protox.DecodeTest do
     },
     {
       "Largest valid string (tests-specific limit of 1 MiB)",
-      <<10, 128, 128, 64>> <> <<0::integer-size(1024 * 1024)-unit(8)>>,
-      %StringsAreUTF8{a: <<0::integer-size(1024 * 1024)-unit(8)>>}
+      <<10, 128, 128, 64>> <> <<0::integer-size(1_048_576)-unit(8)>>,
+      %StringsAreUTF8{a: <<0::integer-size(1_048_576)-unit(8)>>}
     }
   ]
 
@@ -1109,7 +1109,7 @@ defmodule Protox.DecodeTest do
     },
     {
       "too large a string (tests-specific limit of 1 MiB)",
-      <<10, 129, 128, 64>> <> <<0::integer-size(1024 * 1024 + 1)-unit(8)>>,
+      <<10, 129, 128, 64>> <> <<0::integer-size(1_048_576 + 1)-unit(8)>>,
       StringsAreUTF8,
       {Protox.DecodingError,
        quote do

--- a/test/protox/decode_test.exs
+++ b/test/protox/decode_test.exs
@@ -944,6 +944,11 @@ defmodule Protox.DecodeTest do
       "Empty repeated string (second occurence)",
       <<18, 5, "hello", 18, 0>>,
       %StringsAreUTF8{b: ["hello", ""]}
+    },
+    {
+      "Largest valid string (tests-specific limit of 1 MiB)",
+      <<10, 128, 128, 64>> <> <<0::integer-size(1024 * 1024)-unit(8)>>,
+      %StringsAreUTF8{a: <<0::integer-size(1024 * 1024)-unit(8)>>}
     }
   ]
 
@@ -1100,6 +1105,15 @@ defmodule Protox.DecodeTest do
       {Protox.DecodingError,
        quote do
          ~r/string is not valid UTF-8/
+       end}
+    },
+    {
+      "too large a string (tests-specific limit of 1 MiB)",
+      <<10, 129, 128, 64>> <> <<0::integer-size(1024 * 1024 + 1)-unit(8)>>,
+      StringsAreUTF8,
+      {Protox.DecodingError,
+       quote do
+         ~r/string is too large/
        end}
     }
   ]

--- a/test/protox/decode_test.exs
+++ b/test/protox/decode_test.exs
@@ -6,6 +6,9 @@ end
 defmodule Protox.DecodeTest do
   use ExUnit.Case
 
+  @max_valid_string_size Protox.String.max_size()
+  @min_invalid_string_size Protox.String.max_size() + 1
+
   @success_tests [
     {
       "Sub.a",
@@ -947,8 +950,8 @@ defmodule Protox.DecodeTest do
     },
     {
       "Largest valid string (tests-specific limit of 1 MiB)",
-      <<10, 128, 128, 64>> <> <<0::integer-size(1_048_576)-unit(8)>>,
-      %StringsAreUTF8{a: <<0::integer-size(1_048_576)-unit(8)>>}
+      <<10, 128, 128, 64>> <> <<0::integer-size(@max_valid_string_size)-unit(8)>>,
+      %StringsAreUTF8{a: <<0::integer-size(@max_valid_string_size)-unit(8)>>}
     }
   ]
 
@@ -1109,7 +1112,7 @@ defmodule Protox.DecodeTest do
     },
     {
       "too large a string (tests-specific limit of 1 MiB)",
-      <<10, 129, 128, 64>> <> <<0::integer-size(1_048_576 + 1)-unit(8)>>,
+      <<10, 129, 128, 64>> <> <<0::integer-size(@min_invalid_string_size)-unit(8)>>,
       StringsAreUTF8,
       {Protox.DecodingError,
        quote do

--- a/test/protox/encode_test.exs
+++ b/test/protox/encode_test.exs
@@ -411,11 +411,12 @@ defmodule Protox.EncodeTest do
   end
 
   test "Largest valid string" do
-    # Tests-specific limit of 1 MiB
-    assert %StringsAreUTF8{a: <<0::integer-size(1_048_576)-unit(8)>>}
+    string_size = Protox.String.max_size()
+
+    assert %StringsAreUTF8{a: <<0::integer-size(string_size)-unit(8)>>}
            |> Protox.encode!()
            |> IO.iodata_to_binary() ==
-             <<10, 128, 128, 64>> <> <<0::integer-size(1_048_576)-unit(8)>>
+             <<10, 128, 128, 64>> <> <<0::integer-size(string_size)-unit(8)>>
   end
 
   test "Raise when string is not valid UTF-8" do
@@ -446,9 +447,10 @@ defmodule Protox.EncodeTest do
   end
 
   test "Raise when string is too large" do
-    # Tests-specific limit of 1 MiB
+    string_size = Protox.String.max_size() + 1
+
     assert_raise(Protox.EncodingError, ~r/Could not encode field :a /, fn ->
-      %StringsAreUTF8{a: <<0::integer-size(1_048_576 + 1)-unit(8)>>}
+      %StringsAreUTF8{a: <<0::integer-size(string_size)-unit(8)>>}
       |> Protox.encode!()
     end)
   end

--- a/test/protox/encode_test.exs
+++ b/test/protox/encode_test.exs
@@ -412,10 +412,10 @@ defmodule Protox.EncodeTest do
 
   test "Largest valid string" do
     # Tests-specific limit of 1 MiB
-    assert %StringsAreUTF8{a: <<0::integer-size(1024 * 1024)-unit(8)>>}
+    assert %StringsAreUTF8{a: <<0::integer-size(1_048_576)-unit(8)>>}
            |> Protox.encode!()
            |> IO.iodata_to_binary() ==
-             <<10, 128, 128, 64>> <> <<0::integer-size(1024 * 1024)-unit(8)>>
+             <<10, 128, 128, 64>> <> <<0::integer-size(1_048_576)-unit(8)>>
   end
 
   test "Raise when string is not valid UTF-8" do
@@ -448,7 +448,7 @@ defmodule Protox.EncodeTest do
   test "Raise when string is too large" do
     # Tests-specific limit of 1 MiB
     assert_raise(Protox.EncodingError, ~r/Could not encode field :a /, fn ->
-      %StringsAreUTF8{a: <<0::integer-size(1024 * 1024 + 1)-unit(8)>>}
+      %StringsAreUTF8{a: <<0::integer-size(1_048_576 + 1)-unit(8)>>}
       |> Protox.encode!()
     end)
   end

--- a/test/samples/messages.proto
+++ b/test/samples/messages.proto
@@ -104,3 +104,8 @@ message OptionalUpperMsg {
 message OptionalSubMsg {
   int32 a = 1;
 }
+
+message StringsAreUTF8 {
+  string a = 1;
+  repeated string b = 2;
+}


### PR DESCRIPTION
Hi, I've been using `protox` for a while and it works like a charm, thanks for sharing it!

Earlier today I ran into something I didn't expect: after decoding a particular message, a repeated string field contained non-UTF8 binaries.

Accoring to [the protobuf language guide](https://protobuf.dev/programming-guides/proto3/#scalar), strings "must always contain UTF-8 encoded or 7-bit ASCII text, and cannot be longer than 2**32."

This PR proposes changes to achieve that validation, both when encoding and decoding. New tests were also added.

If and when it's a good time for you, let me know what do you think.