### PR TITLE
Add NIF-backed varint module

### DIFF
--- a/lib/protox/varint.ex
+++ b/lib/protox/varint.ex
@@ -1,4 +1,10 @@
-defmodule Protox.Varint do
+if Code.ensure_loaded?(Protox.Varint.Native) do
+  defmodule Protox.Varint do
+    defdelegate encode(v), to: Protox.Varint.Native
+    defdelegate decode(b), to: Protox.Varint.Native
+  end
+else
+  defmodule Protox.Varint do
   @moduledoc false
   # Internal. Implement LEB128 compression.
 
@@ -85,4 +91,5 @@ defmodule Protox.Varint do
   defp do_decode(_result, _shift, bytes) do
     raise Protox.DecodingError.new(bytes, "invalid varint")
   end
+end
 end

--- a/lib/protox/varint/native.ex
+++ b/lib/protox/varint/native.ex
@@ -1,0 +1,7 @@
+defmodule Protox.Varint.Native do
+  @moduledoc false
+  use Rustler, otp_app: :protox, crate: "varint_nif"
+
+  def encode(_int), do: :erlang.nif_error(:nif_not_loaded)
+  def decode(_bin), do: :erlang.nif_error(:nif_not_loaded)
+end

--- a/mix.exs
+++ b/mix.exs
@@ -9,6 +9,8 @@ defmodule Protox.Mixfile do
       build_embedded: Mix.env() == :prod,
       start_permanent: Mix.env() == :prod,
       deps: deps(),
+      compilers: [:rustler] ++ Mix.compilers(),
+      rustler_crates: [varint_nif: [path: "native/varint_nif", mode: (Mix.env() == :prod && :release || :debug)]],
       test_coverage: [tool: ExCoveralls],
       elixirc_paths: elixirc_paths(Mix.env()),
       escript: escript(),
@@ -40,7 +42,8 @@ defmodule Protox.Mixfile do
       {:ex_doc, "~> 0.22", only: [:dev], runtime: false},
       {:propcheck, github: "alfert/propcheck", ref: "c564e89d", only: [:test, :dev]},
       {:stream_data, "~> 1.0", only: [:dev, :test], runtime: false},
-      {:quokka, "~> 2.0", only: [:dev, :test], runtime: false}
+      {:quokka, "~> 2.0", only: [:dev, :test], runtime: false},
+      {:rustler, "~> 0.29"}
     ]
     |> maybe_add_muzak_pro()
     |> maybe_download_protobuf()

--- a/native/varint_nif/Cargo.toml
+++ b/native/varint_nif/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "varint_nif"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+rustler = "0.29"

--- a/native/varint_nif/src/lib.rs
+++ b/native/varint_nif/src/lib.rs
@@ -1,0 +1,41 @@
+use rustler::{Binary, Env, OwnedBinary};
+
+rustler::init!("Elixir.Protox.Varint.Native", [encode, decode]);
+
+#[rustler::nif(schedule = "DirtyCpu")]
+pub fn encode<'a>(env: Env<'a>, value: u64) -> (Binary<'a>, usize) {
+    let mut v = value;
+    let mut bytes = Vec::new();
+    while v >= 0x80 {
+        bytes.push(((v as u8) & 0x7f) | 0x80);
+        v >>= 7;
+    }
+    bytes.push(v as u8);
+    let len = bytes.len();
+    let mut ob = OwnedBinary::new(len).unwrap();
+    ob.as_mut_slice().copy_from_slice(&bytes);
+    (ob.release(env), len)
+}
+
+#[rustler::nif(schedule = "DirtyCpu")]
+pub fn decode<'a>(env: Env<'a>, data: Binary<'a>) -> rustler::NifResult<(u64, Binary<'a>)> {
+    let bytes = data.as_slice();
+    let mut result: u64 = 0;
+    let mut shift = 0;
+    let mut i = 0;
+    while i < bytes.len() {
+        let b = bytes[i];
+        result |= ((b & 0x7f) as u64) << shift;
+        i += 1;
+        if b & 0x80 == 0 {
+            let mut ob = OwnedBinary::new(bytes.len() - i).unwrap();
+            ob.as_mut_slice().copy_from_slice(&bytes[i..]);
+            return Ok((result, ob.release(env)));
+        }
+        shift += 7;
+        if shift > 64 {
+            break;
+        }
+    }
+    Err(rustler::Error::Atom("invalid_varint"))
+}


### PR DESCRIPTION
## Summary
- depend on `rustler`
- compile a new Rust crate `varint_nif`
- call `varint_nif` if available for varint encode/decode

## Testing
- `mix test` *(fails: dependencies could not be fetched)*

------
https://chatgpt.com/codex/tasks/task_e_688cf812b05c8329b270c81663f164fc