### PR TITLE
Fix merging of unknown fields

### DIFF
--- a/lib/protox/merge_message.ex
+++ b/lib/protox/merge_message.ex
@@ -1,6 +1,9 @@
 defmodule Protox.MergeMessage do
   @moduledoc """
   This module provides a helper function to merge messages.
+
+  When merging, unknown fields from both input messages are concatenated and
+  kept as-is. Duplicates are preserved; no deduplication is performed.
   """
 
   alias Protox.{Field, OneOf, Scalar}
@@ -37,8 +40,8 @@ defmodule Protox.MergeMessage do
       :__struct__, v1, _v2 ->
         v1
 
-      ^unknown_fields_name, v1, _v2 ->
-        v1
+      ^unknown_fields_name, v1, v2 ->
+        v1 ++ v2
 
       name, v1, v2 ->
         merge_field(msg, name, v1, v2)

--- a/test/protox_test.exs
+++ b/test/protox_test.exs
@@ -91,6 +91,15 @@ defmodule ProtoxTest do
              %NullHypothesisProto3{}
   end
 
+  test "Merging keeps unknown fields" do
+    msg1 = %NullHypothesisProto3{__uf__: [{10, 2, <<1>>}]}
+    msg2 = %NullHypothesisProto3{__uf__: [{11, 2, <<2>>}]}
+
+    merged = Protox.MergeMessage.merge(msg1, msg2)
+
+    assert merged.__uf__ == msg1.__uf__ ++ msg2.__uf__
+  end
+
   test "Can access required fields of a protobuf 2 message" do
     required_fields =
       TestAllRequiredTypesProto2.schema().fields


### PR DESCRIPTION
## Summary
- correctly merge unknown fields from both messages
- document that merging concatenates unknown fields without deduplication
- test merging preserves unknown fields

## Testing
- `mix deps.get` *(fails: httpc request failed with 503)
- `mix format lib/protox/merge_message.ex test/protox_test.exs` *(fails: missing dependencies)*
- `mix test` *(fails: Unchecked dependencies for environment test)*

------
https://chatgpt.com/codex/tasks/task_e_688fb41e74788329abd67d0a77f44996