### PR TITLE
Replace PropCheck with StreamData

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 Protox is an Elixir library for working with [Google's Protocol Buffers](https://developers.google.com/protocol-buffers), versions 2 and 3, supporting binary encoding and decoding.
 
-The primary objective of Protox is **reliability**: it uses [property testing](https://github.com/alfert/propcheck), [mutation testing](https://github.com/devonestes/muzak) and has a [near 100% code coverage](https://coveralls.io/github/ahamez/protox?branch=master). Protox [passes all the tests](#conformance) of the conformance checker provided by Google.
+The primary objective of Protox is **reliability**: it uses [property testing](https://github.com/whatyouhide/stream_data), [mutation testing](https://github.com/devonestes/muzak) and has a [near 100% code coverage](https://coveralls.io/github/ahamez/protox?branch=master). Protox [passes all the tests](#conformance) of the conformance checker provided by Google.
 
 > [!NOTE]
 > If you're using version 1, please see how to migrate to version 2 [here](documentation/v1_to_v2_migration.md).

--- a/benchmark/mix/tasks/protox/benchmark/generate/payloads.ex
+++ b/benchmark/mix/tasks/protox/benchmark/generate/payloads.ex
@@ -2,7 +2,7 @@ defmodule Mix.Tasks.Protox.Benchmark.Generate.Payloads do
   @moduledoc false
 
   use Mix.Task
-  use PropCheck
+  import StreamData
 
   alias ProtobufTestMessages.Proto3.TestAllTypesProto3
 
@@ -62,12 +62,12 @@ defmodule Mix.Tasks.Protox.Benchmark.Generate.Payloads do
     Logger.info("Generating payload for #{mod}")
 
     gen =
-      let fields <- Protox.RandomInit.generate_fields(mod) do
-        Protox.RandomInit.generate_struct(mod, fields)
-      end
+      bind(Protox.RandomInit.generate_fields(mod), fn fields ->
+        constant(Protox.RandomInit.generate_struct(mod, fields))
+      end)
 
-    Stream.repeatedly(fn -> :proper_gen.pick(gen, 5) end)
-    |> Stream.map(fn {:ok, msg} ->
+    Stream.repeatedly(fn -> gen |> resize(5) |> Enum.at(0) end)
+    |> Stream.map(fn msg ->
       {msg, msg |> Protox.encode!() |> elem(0) |> IO.iodata_to_binary()}
     end)
     |> Stream.reject(fn {_msg, bytes} -> byte_size(bytes) == 0 end)

--- a/mix.exs
+++ b/mix.exs
@@ -38,7 +38,6 @@ defmodule Protox.Mixfile do
       {:dialyxir, "~> 1.0", only: [:test, :dev], runtime: false},
       {:excoveralls, "~> 0.13", only: [:test], runtime: false},
       {:ex_doc, "~> 0.22", only: [:dev], runtime: false},
-      {:propcheck, github: "alfert/propcheck", ref: "c564e89d", only: [:test, :dev]},
       {:stream_data, "~> 1.0", only: [:dev, :test], runtime: false},
       {:quokka, "~> 2.0", only: [:dev, :test], runtime: false}
     ]
@@ -86,7 +85,7 @@ defmodule Protox.Mixfile do
 
   def escript() do
     [
-      # do not start any application: avoid propcheck app to fail when running escript
+      # do not start any application when running the conformance escript
       app: nil,
       main_module: Protox.Conformance.Escript,
       name: "protox_conformance"

--- a/mix.lock
+++ b/mix.lock
@@ -15,8 +15,6 @@
   "makeup_elixir": {:hex, :makeup_elixir, "1.0.1", "e928a4f984e795e41e3abd27bfc09f51db16ab8ba1aebdba2b3a575437efafc2", [:mix], [{:makeup, "~> 1.0", [hex: :makeup, repo: "hexpm", optional: false]}, {:nimble_parsec, "~> 1.2.3 or ~> 1.3", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm", "7284900d412a3e5cfd97fdaed4f5ed389b8f2b4cb49efc0eb3bd10e2febf9507"},
   "makeup_erlang": {:hex, :makeup_erlang, "1.0.2", "03e1804074b3aa64d5fad7aa64601ed0fb395337b982d9bcf04029d68d51b6a7", [:mix], [{:makeup, "~> 1.0", [hex: :makeup, repo: "hexpm", optional: false]}], "hexpm", "af33ff7ef368d5893e4a267933e7744e46ce3cf1f61e2dccf53a111ed3aa3727"},
   "nimble_parsec": {:hex, :nimble_parsec, "1.4.2", "8efba0122db06df95bfaa78f791344a89352ba04baedd3849593bfce4d0dc1c6", [:mix], [], "hexpm", "4b21398942dda052b403bbe1da991ccd03a053668d147d53fb8c4e0efe09c973"},
-  "propcheck": {:git, "https://github.com/alfert/propcheck.git", "c564e89d3873caf9c6bf64a2af4bb3890e24ecf1", [ref: "c564e89d"]},
-  "proper": {:git, "https://github.com/proper-testing/proper.git", "a5ae5669f01143b0828fc21667d4f5e344aa760b", [ref: "a5ae5669f01143b0828fc21667d4f5e344aa760b"]},
   "protobuf": {:git, "https://github.com/protocolbuffers/protobuf.git", "b407e8416e3893036aee5af9a12bd9b6a0e2b2e6", [tag: "v29.3", submodules: true]},
   "quokka": {:hex, :quokka, "2.10.0", "0a29a642f1832c3795af6f6bdf51e25779d5c6253a04c5c4540397e918e9539a", [:mix], [{:credo, "~> 1.7", [hex: :credo, repo: "hexpm", optional: false]}], "hexpm", "ca73c0acdbfa9014bd8d74c23522d0a7b5b64d9a6e30df88741c69acf843657f"},
   "statistex": {:hex, :statistex, "1.0.0", "f3dc93f3c0c6c92e5f291704cf62b99b553253d7969e9a5fa713e5481cd858a5", [:mix], [], "hexpm", "ff9d8bee7035028ab4742ff52fc80a2aa35cece833cf5319009b52f1b5a86c27"},

--- a/test/protox/zigzag_test.exs
+++ b/test/protox/zigzag_test.exs
@@ -1,6 +1,6 @@
 defmodule Protox.ZigzagTest do
   use ExUnit.Case
-  use PropCheck
+  use ExUnitProperties
 
   test "Zigzag encode" do
     assert Protox.Zigzag.encode(0) == 0
@@ -13,8 +13,8 @@ defmodule Protox.ZigzagTest do
 
   @tag :properties
   property "Zigzag encode" do
-    forall value <- integer() do
-      Protox.Zigzag.encode(value) >= 0
+    check all value <- integer() do
+      assert Protox.Zigzag.encode(value) >= 0
     end
   end
 
@@ -29,15 +29,20 @@ defmodule Protox.ZigzagTest do
 
   @tag :properties
   property "Zigzag decode" do
-    forall value <- range(0, 4_294_967_295) do
+    check all value <- integer(0..4_294_967_295) do
       decoded = Protox.Zigzag.decode(value)
-      decoded <= 2_147_483_647 and decoded >= -2_147_483_648
+      assert decoded <= 2_147_483_647
+      assert decoded >= -2_147_483_648
     end
   end
 
-  test "Symmetric" do
-    forall value <- integer() do
-      value == value |> Protox.Zigzag.encode() |> Protox.Zigzag.decode()
+  @tag :properties
+  property "Symmetric" do
+    check all value <- integer() do
+      assert value ==
+               value
+               |> Protox.Zigzag.encode()
+               |> Protox.Zigzag.decode()
     end
   end
 end

--- a/test/protox_properties_test.exs
+++ b/test/protox_properties_test.exs
@@ -1,24 +1,26 @@
 defmodule Protox.PropertiesTest do
   use ExUnit.Case
-  use PropCheck
+  use ExUnitProperties
 
   property "Binary: ProtobufTestMessages.Proto3.TestAllTypesProto3" do
-    forall {msg, encoded, encoded_bin, encoded_size, decoded} <-
-             generate_binary(ProtobufTestMessages.Proto3.TestAllTypesProto3) do
-      is_list(encoded) and decoded == msg and byte_size(encoded_bin) == encoded_size
+    check all {msg, encoded, encoded_bin, encoded_size, decoded} <-
+              generate_binary(ProtobufTestMessages.Proto3.TestAllTypesProto3) do
+      assert is_list(encoded)
+      assert decoded == msg
+      assert byte_size(encoded_bin) == encoded_size
     end
   end
 
   # -- Private
 
   defp generate_binary(mod) do
-    let fields <- Protox.RandomInit.generate_fields(mod) do
+    bind(Protox.RandomInit.generate_fields(mod), fn fields ->
       msg = Protox.RandomInit.generate_struct(mod, fields)
       {:ok, encoded, encoded_size} = Protox.encode(msg)
-      encoded_bin = encoded |> IO.iodata_to_binary()
-      decoded = encoded_bin |> Protox.decode!(mod)
+      encoded_bin = IO.iodata_to_binary(encoded)
+      decoded = Protox.decode!(encoded_bin, mod)
 
-      {msg, encoded, encoded_bin, encoded_size, decoded}
-    end
+      constant({msg, encoded, encoded_bin, encoded_size, decoded})
+    end)
   end
 end

--- a/test/support/random_init.ex
+++ b/test/support/random_init.ex
@@ -259,16 +259,26 @@ defmodule Protox.RandomInit do
   defp get_gen(depth, :map, {key_ty, {:message, sub_msg}}) do
     map_of(
       get_gen(depth, %Scalar{default_value: :dummy}, key_ty),
-      generate_fields(sub_msg, depth - 1)
+      generate_fields(sub_msg, depth - 1),
+      max_length: map_max_length(key_ty)
     )
   end
 
   defp get_gen(depth, :map, {key_ty, value_ty}) do
     map_of(
       get_gen(depth, %Scalar{default_value: :dummy}, key_ty),
-      get_gen(depth, %Scalar{default_value: :dummy}, value_ty)
+      get_gen(depth, %Scalar{default_value: :dummy}, value_ty),
+      max_length: map_max_length(key_ty)
     )
   end
+
+  defp map_max_length(:bool), do: 2
+
+  defp map_max_length({:enum, e}) do
+    e.constants() |> Enum.count() |> min(5)
+  end
+
+  defp map_max_length(_), do: 5
 
   # ----------------------
 


### PR DESCRIPTION
## Summary
- migrate property tests from PropCheck to StreamData
- remove PropCheck dependency and adjust benchmark generator
- document new property-testing approach

## Testing
- `mix deps.get`
- `mix test` *(fails: OptionalMsg1.__struct__/1 is undefined)*

------
https://chatgpt.com/codex/tasks/task_e_6893ad5b3cfc8329a18f760a2aff62d9