### PR TITLE
Fix __MODULE__ resolution in `use Protox` options

### DIFF
--- a/lib/protox.ex
+++ b/lib/protox.ex
@@ -79,7 +79,7 @@ defmodule Protox do
   '''
 
   defmacro __using__(opts) do
-    with {opts, _bindings} <- Code.eval_quoted(opts),
+    with {opts, _bindings} <- Code.eval_quoted(opts, [], __CALLER__),
          {paths, opts} <- get_paths(opts),
          {files, opts} <- get_files(opts),
          {:ok, file_descriptor_set} <- Protox.Protoc.run(files, paths),

--- a/test/module_namespace_test.exs
+++ b/test/module_namespace_test.exs
@@ -1,0 +1,14 @@
+defmodule ModuleNamespaceTest do
+  use ExUnit.Case
+
+  defmodule Module do
+    use Protox,
+      files: [Path.expand("samples/directory/directory_message_1.proto", __DIR__)],
+      namespace: __MODULE__
+  end
+
+  test "use Protox namespaces generated modules under the caller module" do
+    assert Code.ensure_loaded?(ModuleNamespaceTest.Module.DirectoryMessage1)
+    assert ModuleNamespaceTest.Module.DirectoryMessage1.schema().name == ModuleNamespaceTest.Module.DirectoryMessage1
+  end
+end


### PR DESCRIPTION
There is currently a bug in the opts handling of the `Protox.__using__` macro. The macro evaluates opts using `Code.eval_quoted/3` in the callee's environment. When passing `namespace: __MODULE__`, as the example from the readme suggests, `__MODULE__` effectively evaluates to `nil` and has no effect.

This PR passes the `__CALLER__`  env to `Code.eval_quoted/3` so `__MODULE__` is resolved correctly. I've added a test that fails without this change.

---

There is something else to consider for the future that would technically be a breaking change. Instead of using evaluating all options protox could use `Macro.expand_once/2` on just the namespace option, so it doesn't run arbitrary code at compile time and only expands macros where needed.

It could work like this:

``` elixir
opts =
  Enum.map(opts_ast, fn
    {:namespace, value_ast} ->
      {:namespace, Macro.expand_once(value_ast, __CALLER__)}

    other ->
      other
  end)
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved macro caller context handling to ensure protobuf-generated modules are correctly scoped within the caller's module hierarchy, preventing namespace collisions.

* **Tests**
  * Added test suite to validate namespace scoping behavior for generated protobuf modules under caller context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->