### PR TITLE
feat: update Protox module usage to use :prefix instead of :namespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Added
+
+- Add `prefix` as the preferred `use Protox` option for namespace expansion.
+
+### Changed
+
+- Deprecate the `use Protox` `namespace` option in favor of `prefix`, while keeping legacy evaluation semantics for compatibility.
+
 ## 2.0.5
 
 ### Fixed
 
 - Correctly resolve `__MODULE__` in `use Protox` options (thanks to [Luka Dornhecker](https://github.com/lukad))
+- Merging of unknown fields
 
 ## 2.0.4
 

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ end
 ```
 
 > [!NOTE]
-> The module in which the `Protox` macro is called is ignored and does not appear in the names of the generated modules. To include the enclosing module’s name, use the `namespace` option, see [here](#namespaces).
+> The module in which the `Protox` macro is called is ignored and does not appear in the names of the generated modules. To include the enclosing module’s name, use the `prefix` option, see [here](#namespaces).
 
 ## Usage with files
 
@@ -143,7 +143,7 @@ The example above is translated to `Abc.Def.Baz` (package `abc.def` is camelized
 
 ## Namespaces
 
-You can prepend a namespace with a prefix using the `:namespace` option:
+For `use Protox`, you can prepend a namespace with a prefix using the `:prefix` option:
 
 ```elixir
 defmodule Bar do
@@ -156,7 +156,7 @@ defmodule Bar do
         int32 a = 1;
       }
     """,
-    namespace: __MODULE__
+    prefix: __MODULE__
 end
 ```
 
@@ -165,6 +165,8 @@ In this example, the module `Bar.Abc.Msg` is generated:
 ```elixir
 msg = %Bar.Abc.Msg{a: 42}
 ```
+
+The older `:namespace` option is deprecated for `use Protox`, but it remains available for legacy computed expressions.
 
 ## Specify include path
 
@@ -219,6 +221,7 @@ The files will be usable in any project as long as Protox is declared in the dep
 - `--namespace`
 
   [Prepends a namespace](#prepend-namespaces) to all generated modules.
+  This CLI flag is separate from the `use Protox`-only `:prefix` option.
 
 ## Unknown fields
 

--- a/lib/protox.ex
+++ b/lib/protox.ex
@@ -33,6 +33,22 @@ defmodule Protox do
   The generated modules respect the package declaration. For instance, in the above example,
   both the `Fiz.Baz` and `Fiz.Foo` modules will be generated.
 
+  ## Namespaces
+  For `use Protox`, prefer the `:prefix` option when prepending a namespace to generated modules:
+      defmodule Dummy do
+        use Protox,
+          schema: """
+          syntax = "proto3";
+          package fiz;
+
+          message Foo {
+          }
+          """,
+          prefix: __MODULE__
+      end
+
+  The older `:namespace` option is deprecated but still supported for legacy computed expressions.
+
   ## Encoding/decoding
   For the rest of this module documentation, we suppose the following protobuf messages are defined:
       defmodule Dummy do
@@ -54,7 +70,7 @@ defmodule Protox do
               map<int32, Baz> b = 2;
             }
           """,
-          namespace: Namespace
+          prefix: Namespace
 
         use Protox,
           schema: """
@@ -78,9 +94,10 @@ defmodule Protox do
   See each function documentation to see how they are used to encode and decode protobuf messages.
   '''
 
-  defmacro __using__(opts) do
-    with {opts, _bindings} <- Code.eval_quoted(opts, [], __CALLER__),
-         {paths, opts} <- get_paths(opts),
+  defmacro __using__(opts_ast) do
+    opts = normalize_use_opts(opts_ast, __CALLER__)
+
+    with {paths, opts} <- get_paths(opts),
          {files, opts} <- get_files(opts),
          {:ok, file_descriptor_set} <- Protox.Protoc.run(files, paths),
          {:ok, definition} <- Protox.Parse.parse(file_descriptor_set, opts) do
@@ -154,6 +171,87 @@ defmodule Protox do
   end
 
   # -- Private
+
+  defp normalize_use_opts(opts_ast, caller) when is_list(opts_ast) do
+    validate_namespace_conflict!(opts_ast)
+
+    Enum.map(opts_ast, fn
+      {:prefix, value_ast} -> {:namespace, normalize_use_opt(:prefix, value_ast, caller)}
+      {key, value_ast} when is_atom(key) -> {key, normalize_use_opt(key, value_ast, caller)}
+      other -> raise ArgumentError, "invalid Protox option: #{Macro.to_string(other)}"
+    end)
+  end
+
+  defp normalize_use_opts(opts_ast, _caller) do
+    raise ArgumentError,
+          "use Protox expects a keyword list, got: #{Macro.to_string(opts_ast)}"
+  end
+
+  defp normalize_use_opt(:namespace, value_ast, caller) do
+    IO.warn("`use Protox, namespace: ...` is deprecated; use `prefix: ...` instead")
+    eval_option(value_ast, caller)
+  end
+
+  defp normalize_use_opt(:prefix, value_ast, caller) do
+    value_ast
+    |> Macro.expand_once(caller)
+    |> validate_namespace!(:prefix)
+  end
+
+  defp normalize_use_opt(:schema, value_ast, caller) do
+    value_ast
+    |> eval_option(caller)
+    |> validate_option_type!(:schema, &is_binary/1, "a string")
+  end
+
+  defp normalize_use_opt(key, value_ast, caller) when key in [:files, :paths] do
+    value_ast
+    |> eval_option(caller)
+    |> validate_option_type!(
+      key,
+      fn value -> is_list(value) and Enum.all?(value, &is_binary/1) end,
+      "a list of strings"
+    )
+  end
+
+  defp normalize_use_opt(_key, value_ast, caller), do: eval_option(value_ast, caller)
+
+  defp validate_namespace_conflict!(opts_ast) do
+    has_namespace? = Keyword.has_key?(opts_ast, :namespace)
+    has_prefix? = Keyword.has_key?(opts_ast, :prefix)
+
+    if has_namespace? and has_prefix? do
+      raise ArgumentError, "use Protox options :namespace and :prefix are mutually exclusive"
+    end
+  end
+
+  defp eval_option(value_ast, caller) do
+    value_ast
+    |> Code.eval_quoted([], caller)
+    |> elem(0)
+  end
+
+  defp validate_option_type!(value, key, validator, expected) do
+    if validator.(value) do
+      value
+    else
+      raise ArgumentError,
+            "invalid Protox option #{inspect(key)}: expected #{expected}, got: #{inspect(value)}"
+    end
+  end
+
+  defp validate_namespace!({:__aliases__, _, modules}, _key), do: Module.concat(modules)
+  defp validate_namespace!(value, _key) when is_atom(value) or is_binary(value) or is_nil(value), do: value
+
+  defp validate_namespace!(value_ast, key) do
+    raise_invalid_namespace!(key, value_ast)
+  end
+
+  defp raise_invalid_namespace!(key, expanded_ast) do
+    raise ArgumentError,
+          "invalid Protox option #{inspect(key)}: expected an alias, atom, string, or nil, got: " <>
+            Macro.to_string(expanded_ast)
+  end
 
   defp get_paths(opts) do
     case Keyword.pop(opts, :paths) do

--- a/test/module_namespace_test.exs
+++ b/test/module_namespace_test.exs
@@ -1,14 +1,83 @@
 defmodule ModuleNamespaceTest do
   use ExUnit.Case
 
+  import ExUnit.CaptureIO
+
   defmodule Module do
     use Protox,
       files: [Path.expand("samples/directory/directory_message_1.proto", __DIR__)],
-      namespace: __MODULE__
+      prefix: __MODULE__
   end
 
-  test "use Protox namespaces generated modules under the caller module" do
+  test "use Protox namespaces generated modules under the caller module with prefix" do
     assert Code.ensure_loaded?(ModuleNamespaceTest.Module.DirectoryMessage1)
     assert ModuleNamespaceTest.Module.DirectoryMessage1.schema().name == ModuleNamespaceTest.Module.DirectoryMessage1
+  end
+
+  test "use Protox keeps namespace working and warns when given a computed expression" do
+    warning =
+      capture_io(:stderr, fn ->
+        Code.compile_string("""
+        defmodule ModuleNamespaceTest.ComputedNamespace do
+          use Protox,
+            files: [Path.expand("samples/directory/directory_message_1.proto", #{inspect(__DIR__)})],
+            namespace: Module.concat(__MODULE__, Generated)
+        end
+        """)
+      end)
+
+    generated_module = ModuleNamespaceTest.ComputedNamespace.Generated.DirectoryMessage1
+
+    assert warning =~ "`use Protox, namespace: ...` is deprecated; use `prefix: ...` instead"
+    assert Code.ensure_loaded?(generated_module)
+
+    assert apply(generated_module, :schema, []).name == generated_module
+  end
+
+  test "use Protox keeps namespace working and warns when given __MODULE__" do
+    warning =
+      capture_io(:stderr, fn ->
+        Code.compile_string("""
+        defmodule ModuleNamespaceTest.DeprecatedNamespace do
+          use Protox,
+            files: [Path.expand("samples/directory/directory_message_1.proto", #{inspect(__DIR__)})],
+            namespace: __MODULE__
+        end
+        """)
+      end)
+
+    assert warning =~ "`use Protox, namespace: ...` is deprecated; use `prefix: ...` instead"
+    assert Code.ensure_loaded?(ModuleNamespaceTest.DeprecatedNamespace.DirectoryMessage1)
+  end
+
+  test "use Protox rejects computed prefix expressions" do
+    assert_raise ArgumentError,
+                 ~r/invalid Protox option :prefix/,
+                 fn ->
+                   Code.compile_string("""
+                   defmodule ModuleNamespaceTest.InvalidPrefix do
+                     def namespace, do: __MODULE__.Generated
+
+                     use Protox,
+                       files: [Path.expand("samples/directory/directory_message_1.proto", #{inspect(__DIR__)})],
+                       prefix: namespace()
+                   end
+                   """)
+                 end
+  end
+
+  test "use Protox rejects namespace and prefix together" do
+    assert_raise ArgumentError,
+                 ~r/options :namespace and :prefix are mutually exclusive/,
+                 fn ->
+                   Code.compile_string("""
+                   defmodule ModuleNamespaceTest.ConflictingNamespaceOptions do
+                     use Protox,
+                       files: [Path.expand("samples/directory/directory_message_1.proto", #{inspect(__DIR__)})],
+                       namespace: __MODULE__,
+                       prefix: __MODULE__
+                   end
+                   """)
+                 end
   end
 end


### PR DESCRIPTION
Deprecate :namespace option in favor of :prefix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced `prefix` option as the preferred approach for namespace configuration.

* **Changed**
  * Deprecated `namespace` option in favor of `prefix`; legacy evaluation semantics preserved for backward compatibility.

* **Bug Fixes**
  * Improved merging of unknown fields.

* **Documentation**
  * Updated guides and examples to reflect the new `prefix` option usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->