### PR TITLE
fix: avoid quadratic unknown field decode cost

### DIFF
--- a/lib/protox/define_decoder.ex
+++ b/lib/protox/define_decoder.ex
@@ -62,9 +62,13 @@ defmodule Protox.DefineDecoder do
     parse_key_value_body =
       make_parse_key_value_body(fields, vars, opts)
 
+    unknown_fields_name = Keyword.fetch!(opts, :unknown_fields_name)
+
     quote do
       @spec parse_key_value(binary(), struct()) :: struct()
-      defp parse_key_value(<<>>, msg), do: msg
+      defp parse_key_value(<<>>, msg) do
+        %{msg | unquote(unknown_fields_name) => Enum.reverse(msg.unquote(unknown_fields_name))}
+      end
 
       defp parse_key_value(bytes, msg), do: unquote(parse_key_value_body)
     end
@@ -136,8 +140,7 @@ defmodule Protox.DefineDecoder do
       quote do
         {
           unquote(unknown_fields_name),
-          # Order is important here, we want to keep the order of the unknown fields.
-          unquote(vars.msg).unquote(unknown_fields_name) ++ [unquote(vars.value)]
+          [unquote(vars.value) | unquote(vars.msg).unquote(unknown_fields_name)]
         }
       end
 


### PR DESCRIPTION
### Motivation
- A recent change accumulated unknown fields with `list ++ [value]`, which is O(n) per field and makes decoding messages with many unknown fields O(n²), creating a CPU-exhaustion DoS vector. 
- The goal is to preserve the externally-observed unknown-field order while restoring linear-time decoding cost.

### Description
- Replaced per-field append with O(1) prepend when accumulating unknown fields in the generated decoder by switching to `[value | list]` in `lib/protox/define_decoder.ex`. 
- Added a finalization step in the decoder base case to `Enum.reverse/1` the unknown-fields list before returning so the original order is preserved. 
- Fetches `unknown_fields_name` from the generation `opts` so the generated base-case can update the appropriate struct field.

### Testing
- Attempted to run the affected unit tests with `mix test test/protox/decode_test.exs`, but the environment lacked `mix` so the run failed with `/bin/bash: mix: command not found` and no tests were executed. 
- No automated tests were run successfully in this environment; please run the full test suite (`mix test` and optionally `mix test --include conformance`) in CI or a local environment to validate behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69d0e0b9e938832ebfac58920b9daec2)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected unknown field handling during protocol buffer deserialization to ensure proper field ordering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->