### PR TITLE
fix: enforce strict wire-type matching for length-delimited decoder clauses

### DIFF
--- a/lib/protox/define_decoder.ex
+++ b/lib/protox/define_decoder.ex
@@ -227,8 +227,6 @@ defmodule Protox.DefineDecoder do
 
     clause =
       if single_generated do
-        # If the single clause was not generated for this field, we don't need the wire type
-        # discrimant as there is only one clause matching for this field.
         quote do
           <<unquote(key_bytes), unquote(vars.bytes)::binary>>
         end
@@ -238,12 +236,12 @@ defmodule Protox.DefineDecoder do
         case tail do
           "" ->
             quote do
-              <<unquote(first_byte)::5, _wire_type::3, unquote(vars.bytes)::binary>>
+              <<unquote(first_byte)::5, unquote(@wire_delimited)::3, unquote(vars.bytes)::binary>>
             end
 
           _ ->
             quote do
-              <<unquote(first_byte)::5, _wire_type::3, unquote(tail), unquote(vars.bytes)::binary>>
+              <<unquote(first_byte)::5, unquote(@wire_delimited)::3, unquote(tail), unquote(vars.bytes)::binary>>
             end
         end
       end

--- a/test/protox/decode_test.exs
+++ b/test/protox/decode_test.exs
@@ -413,6 +413,19 @@ defmodule Protox.DecodeTest do
       >>,
       TestAllTypesProto3,
       Protox.DecodingError
+    },
+    {
+      "length-delimited field with varint wire type",
+      <<
+        # Field 14 (optional_string) encoded with wire type 0 (varint)
+        14 <<< 3 ||| 0,
+        # Value parsed as varint in unknown field path
+        1,
+        # Invalid tag to ensure the previous field was skipped, not parsed as string
+        0
+      >>,
+      TestAllTypesProto3,
+      Protox.IllegalTagError
     }
   ]
 


### PR DESCRIPTION
### Motivation
- A refactor made length-delimited-only fields (string/bytes/message/map) accept any wire type by emitting a wildcard match, which allowed malformed protobufs to be parsed as length-delimited and enabled DoS or data corruption via `decode!`.
- The change restores the original strict wire-type discrimination so malformed inputs are rejected instead of misparsed.

### Description
- Require the protobuf length-delimited wire type in generated delimited clauses by using `@wire_delimited` instead of a wildcard when `single_generated` is `false` in `make_delimited_case_impl/3` in `lib/protox/define_decoder.ex`.
- Preserve the existing behavior for the `single_generated` path where the full `key_bytes` match is used unchanged.
- Add a regression test in `test/protox/decode_test.exs` that verifies a length-delimited field encoded with a varint wire type is rejected (expected `Protox.IllegalTagError`).

### Testing
- Attempted to run the regression test with `mix test test/protox/decode_test.exs`, but the execution environment does not have `mix`/`elixir` installed so automated tests could not be executed here.  The new test has been added and should run in CI or a local Elixir environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69d0e41eb5ec832e842a5a783c7ac8e9)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced decoder validation for packed repeated fields with stricter wire type matching, improving detection of malformed protocol buffer messages.

* **Tests**
  * Added test coverage for error handling when fields receive incorrect wire types during message decoding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->