### PR TITLE
Fix quadratic decoding (repeated elements)

### DIFF
--- a/lib/protox/define_decoder.ex
+++ b/lib/protox/define_decoder.ex
@@ -87,8 +87,7 @@ defmodule Protox.DefineDecoder do
         {field_name, quote(do: Enum.reverse(unquote(msg_var).unquote(field_name)))}
       end) ++
         [
-          {unknown_fields_name,
-           quote(do: Enum.reverse(unquote(msg_var).unquote(unknown_fields_name)))}
+          {unknown_fields_name, quote(do: Enum.reverse(unquote(msg_var).unquote(unknown_fields_name)))}
         ]
 
     quote do
@@ -334,8 +333,7 @@ defmodule Protox.DefineDecoder do
     quote(do: {unquote(field.name), unquote(value)})
   end
 
-  defp make_update_field(value, %Field{kind: kind} = field, vars, wrap_value)
-       when kind in [:packed, :unpacked] do
+  defp make_update_field(value, %Field{kind: kind} = field, vars, wrap_value) when kind in [:packed, :unpacked] do
     update_value =
       if wrap_value do
         quote(do: [unquote(value) | unquote(vars.msg).unquote(field.name)])

--- a/lib/protox/define_decoder.ex
+++ b/lib/protox/define_decoder.ex
@@ -63,14 +63,36 @@ defmodule Protox.DefineDecoder do
       make_parse_key_value_body(fields, vars, opts)
 
     unknown_fields_name = Keyword.fetch!(opts, :unknown_fields_name)
+    finish_decode = make_finish_decode(fields, vars.msg, unknown_fields_name)
 
     quote do
       @spec parse_key_value(binary(), struct()) :: struct()
       defp parse_key_value(<<>>, msg) do
-        %{msg | unquote(unknown_fields_name) => Enum.reverse(msg.unquote(unknown_fields_name))}
+        unquote(finish_decode)
       end
 
       defp parse_key_value(bytes, msg), do: unquote(parse_key_value_body)
+    end
+  end
+
+  defp make_finish_decode(fields, msg_var, unknown_fields_name) do
+    repeated_field_names =
+      fields
+      |> Enum.filter(&(&1.kind in [:packed, :unpacked]))
+      |> Enum.map(& &1.name)
+      |> Enum.uniq()
+
+    updates =
+      Enum.map(repeated_field_names, fn field_name ->
+        {field_name, quote(do: Enum.reverse(unquote(msg_var).unquote(field_name)))}
+      end) ++
+        [
+          {unknown_fields_name,
+           quote(do: Enum.reverse(unquote(msg_var).unquote(unknown_fields_name)))}
+        ]
+
+    quote do
+      %{unquote(msg_var) | unquote_splicing(updates)}
     end
   end
 
@@ -310,6 +332,20 @@ defmodule Protox.DefineDecoder do
 
   defp make_update_field(value, %Field{kind: %Scalar{}} = field, _vars, _wrap_value) do
     quote(do: {unquote(field.name), unquote(value)})
+  end
+
+  defp make_update_field(value, %Field{kind: kind} = field, vars, wrap_value)
+       when kind in [:packed, :unpacked] do
+    update_value =
+      if wrap_value do
+        quote(do: [unquote(value) | unquote(vars.msg).unquote(field.name)])
+      else
+        quote(do: Enum.reverse(unquote(value), unquote(vars.msg).unquote(field.name)))
+      end
+
+    quote do
+      {unquote(field.name), unquote(update_value)}
+    end
   end
 
   defp make_update_field(value, %Field{} = field, vars, wrap_value) do

--- a/test/protox/decode_test.exs
+++ b/test/protox/decode_test.exs
@@ -49,6 +49,12 @@ defmodule Protox.DecodeTest do
       %TestAllTypesProto3{repeated_bool: [true, false, true, false]}
     },
     {
+      "Repeated bool, unpacked and packed, should be concatenated (2)",
+      # unpacked <> packed
+      <<218, 2, 1, 1, 218, 2, 1, 0>> <> <<218, 2, 2, 1, 0>>,
+      %TestAllTypesProto3{repeated_bool: [true, false, true, false]}
+    },
+    {
       "Repeated uint32",
       <<138, 2, 6, 0, 1, 2, 3, 144, 78>>,
       %TestAllTypesProto3{repeated_uint32: [0, 1, 2, 3, 10_000]}

--- a/test/protox/generate_test.exs
+++ b/test/protox/generate_test.exs
@@ -161,7 +161,8 @@ defmodule Protox.GenerateTest do
     refute content =~ "msg.repeated_string ++"
     refute content =~ "msg.repeated_nested_message ++"
 
-    assert content =~ ~r/repeated_string:\s*\[\s*Protox\.Decode\.validate_string!\(delimited\)\s*\|\s*msg\.repeated_string\s*\]/s
+    assert content =~
+             ~r/repeated_string:\s*\[\s*Protox\.Decode\.validate_string!\(delimited\)\s*\|\s*msg\.repeated_string\s*\]/s
 
     assert content =~ "repeated_string: Enum.reverse(msg.repeated_string)"
     assert content =~ "repeated_bool: Enum.reverse(msg.repeated_bool)"

--- a/test/protox/generate_test.exs
+++ b/test/protox/generate_test.exs
@@ -142,4 +142,28 @@ defmodule Protox.GenerateTest do
     assert Code.compile_file(namespace_directory_message1_tmp_file) != []
     assert Code.compile_file(namespace_sub_directory_message_tmp_file) != []
   end
+
+  test "Generate repeated-field decoders with prepend-and-reverse" do
+    file = Path.join(__DIR__, "../samples/google/test_messages_proto3.proto")
+    generated_file_name = "generated_repeated_decode.ex"
+
+    {:ok, files_content} =
+      Protox.Generate.generate_module_code([file], generated_file_name, false, [
+        "./test/samples/google"
+      ])
+
+    assert [%Protox.Generate.FileContent{name: ^generated_file_name, content: content}] =
+             files_content
+
+    content = IO.iodata_to_binary(content)
+
+    refute content =~ "msg.repeated_bool ++"
+    refute content =~ "msg.repeated_string ++"
+    refute content =~ "msg.repeated_nested_message ++"
+
+    assert content =~ ~r/repeated_string:\s*\[\s*Protox\.Decode\.validate_string!\(delimited\)\s*\|\s*msg\.repeated_string\s*\]/s
+
+    assert content =~ "repeated_string: Enum.reverse(msg.repeated_string)"
+    assert content =~ "repeated_bool: Enum.reverse(msg.repeated_bool)"
+  end
 end


### PR DESCRIPTION
This changes generated decoders for repeated fields to use prepend-and-reverse
instead of repeated append.

Before, generated code built repeated fields with `msg.field ++ [value]`, which
makes decoding quadratic in the number of repeated elements because the left-hand
list is copied on every append. For large repeated fields, that causes
unnecessary CPU work and memory churn.

With this change, generated decoders:

  - prepend unpacked repeated values with `[value | msg.field]`
  - prepend packed repeated segments with `Enum.reverse(segment, msg.field)`
  - reverse repeated fields once when decoding finishes

This preserves field order while reducing repeated-field decoding from O(n^2) to O(n).

Tests were added to cover both the generated code shape and runtime decode behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved protobuf message decoding for repeated fields, including correct handling of interleaved packed and unpacked representations.
  * Enhanced performance of repeated field decoding through optimized list accumulation strategy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->