### PR TITLE
Remove :mix from extra_applications

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -18,7 +18,10 @@ defmodule Protox.Mixfile do
       package: package(),
       dialyzer: [
         plt_local_path: "priv/plts",
-        plt_add_apps: [:logger, :stream_data]
+        # :mix is not a runtime dependency (see `application/0`), but the
+        # mix tasks and dev/test tooling reference it — keep it in the PLT
+        # so dialyzer can see those modules.
+        plt_add_apps: [:logger, :mix, :stream_data]
       ],
       docs: docs()
     ]

--- a/mix.exs
+++ b/mix.exs
@@ -33,7 +33,7 @@ defmodule Protox.Mixfile do
 
   def application() do
     [
-      extra_applications: [:eex, :mix]
+      extra_applications: [:eex]
     ]
   end
 


### PR DESCRIPTION
Closes #299 — thanks for being open to the change!

## What

Removes `:mix` from `extra_applications` (`[:eex, :mix]` → `[:eex]`). One-line diff.

## Why

Declaring `:mix` as an OTP application ships Mix's modules into every consumer's `mix release`, with the application present on the code path but never started. Protox's runtime (encode/decode of generated modules) never touches Mix:

- `Mix.env/0` in `Protox.String` and `Mix.Project.config/0` in `Protox.TmpFs` both execute at **compile time** (module-body `if` / module attribute), where Mix is always available.
- The `protox.generate` task and codegen only ever run under Mix by definition.

Beyond release bloat, the phantom Mix modules bite anything that probes for Mix at runtime — most recently phoenix 1.8.10's CodeReloader boot check: `Code.ensure_loaded?(Mix.Project)` succeeded, the follow-up call hit the never-started `Mix.ProjectStack`, and releases crash-looped at boot (phoenixframework/phoenix#6789; fixed on their side in 1.8.11, but protox consumers shouldn't be exposed to that class of bug at all).

## Validation

- `lib/` compiles with **zero warnings** without the declaration (the compile-time Mix calls happen under Mix, so no app-boundary warnings).
- Precedent: `tailwind` and `esbuild` also ship mix tasks and declare no `:mix`.

Unrelated note observed while testing: `conformance/protox/conformance/escript.ex` currently fails to compile on Elixir 1.20.3 on master (dev-only paths, doesn't affect consumers) — happy to file separately if useful.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved development tooling configuration for more reliable analysis of Mix-based tasks.
  * Streamlined application startup configuration while preserving required templating support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Removes `:mix` from Protox's runtime OTP applications while retaining it in the Dialyzer PLT for development and tooling analysis.
- Keeps `:eex` as the sole runtime extra application.
- Preserves Dialyzer visibility into Mix-backed tasks and development tooling.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| mix.exs | Separates Mix's compile-time and tooling use from runtime application startup without leaving a reachable runtime dependency. |

</details>

<sub>Reviews (2): Last reviewed commit: ["Keep :mix in the dialyzer PLT"](https://github.com/ahamez/protox/commit/8ecf0d1783542316190aa76388036cebde0aaf04) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52741545)</sub>

<!-- /greptile_comment -->