### PR TITLE
Binary matching optimization

### DIFF
--- a/lib/protox/decode.ex
+++ b/lib/protox/decode.ex
@@ -17,6 +17,7 @@ defmodule Protox.Decode do
   @max_field_number (1 <<< 29) - 1
 
   @compile {:inline,
+            parse_delimited: 2,
             parse_bool: 1,
             parse_sint32: 1,
             parse_sint64: 1,
@@ -338,12 +339,12 @@ defmodule Protox.Decode do
 
   @spec parse_delimited(binary(), non_neg_integer()) :: {binary(), binary()} | no_return()
   def parse_delimited(bytes, len) do
-    <<value::binary-size(^len), rest::binary>> = bytes
+    case bytes do
+      <<value::binary-size(^len), rest::binary>> ->
+        {value, rest}
 
-    {value, rest}
-  rescue
-    _error ->
-      reraise Protox.DecodingError.new(bytes, "invalid bytes for delimited field"),
-              __STACKTRACE__
+      _ ->
+        raise Protox.DecodingError.new(bytes, "invalid bytes for delimited field")
+    end
   end
 end

--- a/lib/protox/decode.ex
+++ b/lib/protox/decode.ex
@@ -302,6 +302,13 @@ defmodule Protox.Decode do
   @spec parse_repeated_fixed32([non_neg_integer()], binary()) :: [non_neg_integer()]
   def parse_repeated_fixed32(acc, <<>>), do: Enum.reverse(acc)
 
+  def parse_repeated_fixed32(
+        acc,
+        <<a::unsigned-little-32, b::unsigned-little-32, c::unsigned-little-32, d::unsigned-little-32, rest::binary>>
+      ) do
+    parse_repeated_fixed32([d, c, b, a | acc], rest)
+  end
+
   def parse_repeated_fixed32(acc, bytes) do
     {value, rest} = parse_fixed32(bytes)
     parse_repeated_fixed32([value | acc], rest)
@@ -309,6 +316,13 @@ defmodule Protox.Decode do
 
   @spec parse_repeated_fixed64([non_neg_integer()], binary()) :: [non_neg_integer()]
   def parse_repeated_fixed64(acc, <<>>), do: Enum.reverse(acc)
+
+  def parse_repeated_fixed64(
+        acc,
+        <<a::unsigned-little-64, b::unsigned-little-64, c::unsigned-little-64, d::unsigned-little-64, rest::binary>>
+      ) do
+    parse_repeated_fixed64([d, c, b, a | acc], rest)
+  end
 
   def parse_repeated_fixed64(acc, bytes) do
     {value, rest} = parse_fixed64(bytes)
@@ -318,6 +332,13 @@ defmodule Protox.Decode do
   @spec parse_repeated_sfixed32([integer()], binary()) :: [integer()]
   def parse_repeated_sfixed32(acc, <<>>), do: Enum.reverse(acc)
 
+  def parse_repeated_sfixed32(
+        acc,
+        <<a::signed-little-32, b::signed-little-32, c::signed-little-32, d::signed-little-32, rest::binary>>
+      ) do
+    parse_repeated_sfixed32([d, c, b, a | acc], rest)
+  end
+
   def parse_repeated_sfixed32(acc, bytes) do
     {value, rest} = parse_sfixed32(bytes)
     parse_repeated_sfixed32([value | acc], rest)
@@ -325,6 +346,13 @@ defmodule Protox.Decode do
 
   @spec parse_repeated_sfixed64([integer()], binary()) :: [integer()]
   def parse_repeated_sfixed64(acc, <<>>), do: Enum.reverse(acc)
+
+  def parse_repeated_sfixed64(
+        acc,
+        <<a::signed-little-64, b::signed-little-64, c::signed-little-64, d::signed-little-64, rest::binary>>
+      ) do
+    parse_repeated_sfixed64([d, c, b, a | acc], rest)
+  end
 
   def parse_repeated_sfixed64(acc, bytes) do
     {value, rest} = parse_sfixed64(bytes)
@@ -336,6 +364,15 @@ defmodule Protox.Decode do
         ]
   def parse_repeated_float(acc, <<>>), do: Enum.reverse(acc)
 
+  # A float segment never matches NaN or infinity payloads: those fall through
+  # to the single-element clause below, which handles them.
+  def parse_repeated_float(
+        acc,
+        <<a::float-little-32, b::float-little-32, c::float-little-32, d::float-little-32, rest::binary>>
+      ) do
+    parse_repeated_float([d, c, b, a | acc], rest)
+  end
+
   def parse_repeated_float(acc, bytes) do
     {value, rest} = parse_float(bytes)
     parse_repeated_float([value | acc], rest)
@@ -345,6 +382,15 @@ defmodule Protox.Decode do
           float() | :infinity | :"-infinity" | :nan
         ]
   def parse_repeated_double(acc, <<>>), do: Enum.reverse(acc)
+
+  # A float segment never matches NaN or infinity payloads: those fall through
+  # to the single-element clause below, which handles them.
+  def parse_repeated_double(
+        acc,
+        <<a::float-little-64, b::float-little-64, c::float-little-64, d::float-little-64, rest::binary>>
+      ) do
+    parse_repeated_double([d, c, b, a | acc], rest)
+  end
 
   def parse_repeated_double(acc, bytes) do
     {value, rest} = parse_double(bytes)

--- a/lib/protox/decode.ex
+++ b/lib/protox/decode.ex
@@ -97,7 +97,7 @@ defmodule Protox.Decode do
       <<unknown_bytes::binary-size(^len), rest::binary>> ->
         {{tag, @wire_delimited, unknown_bytes}, rest}
 
-      _ ->
+      _invalid_bytes ->
         raise Protox.DecodingError.new(bytes, "invalid bytes for unknown delimited")
     end
   end
@@ -403,7 +403,7 @@ defmodule Protox.Decode do
       <<value::binary-size(^len), rest::binary>> ->
         {value, rest}
 
-      _ ->
+      _invalid_bytes ->
         raise Protox.DecodingError.new(bytes, "invalid bytes for delimited field")
     end
   end

--- a/lib/protox/decode.ex
+++ b/lib/protox/decode.ex
@@ -79,8 +79,11 @@ defmodule Protox.Decode do
   @spec parse_unknown(non_neg_integer(), Protox.Types.tag(), binary()) ::
           {{non_neg_integer(), Protox.Types.tag(), binary()}, binary()}
   def parse_unknown(tag, @wire_varint, bytes) do
-    {unknown_bytes, rest} = get_unknown_varint_bytes(<<>>, bytes)
-    {{tag, @wire_varint, unknown_bytes}, rest}
+    size = unknown_varint_size(bytes, 0)
+    <<unknown_bytes::binary-size(^size), rest::binary>> = bytes
+
+    # Copied so the stored unknown bytes don't keep the whole payload alive.
+    {{tag, @wire_varint, :binary.copy(unknown_bytes)}, rest}
   end
 
   def parse_unknown(tag, @wire_64bits, <<unknown_bytes::64, rest::binary>>) do
@@ -90,13 +93,12 @@ defmodule Protox.Decode do
   def parse_unknown(tag, @wire_delimited, bytes) do
     {len, new_bytes} = Varint.decode(bytes)
 
-    try do
-      <<unknown_bytes::binary-size(^len), rest::binary>> = new_bytes
-      {{tag, @wire_delimited, unknown_bytes}, rest}
-    rescue
-      _error ->
-        reraise Protox.DecodingError.new(bytes, "invalid bytes for unknown delimited"),
-                __STACKTRACE__
+    case new_bytes do
+      <<unknown_bytes::binary-size(^len), rest::binary>> ->
+        {{tag, @wire_delimited, unknown_bytes}, rest}
+
+      _ ->
+        raise Protox.DecodingError.new(bytes, "invalid bytes for unknown delimited")
     end
   end
 
@@ -108,15 +110,13 @@ defmodule Protox.Decode do
     raise Protox.DecodingError.new(bytes, "can't parse unknown bytes")
   end
 
-  defp get_unknown_varint_bytes(acc, <<0::1, b::7, rest::binary>>) do
-    {<<acc::binary, 0::1, b::7>>, rest}
+  defp unknown_varint_size(<<0::1, _byte::7, _rest::binary>>, acc), do: acc + 1
+
+  defp unknown_varint_size(<<1::1, _byte::7, rest::binary>>, acc) do
+    unknown_varint_size(rest, acc + 1)
   end
 
-  defp get_unknown_varint_bytes(acc, <<1::1, b::7, rest::binary>>) do
-    get_unknown_varint_bytes(<<acc::binary, 1::1, b::7>>, rest)
-  end
-
-  defp get_unknown_varint_bytes(_acc, bytes) do
+  defp unknown_varint_size(bytes, _acc) do
     raise Protox.DecodingError.new(bytes, "can't parse unknown varint bytes")
   end
 

--- a/lib/protox/decode.ex
+++ b/lib/protox/decode.ex
@@ -56,11 +56,11 @@ defmodule Protox.Decode do
   def parse_key(bytes) do
     {key, rest} = Varint.decode(bytes)
     key_size = byte_size(bytes) - byte_size(rest)
-    key_bytes = binary_part(bytes, 0, key_size)
     field_number = key >>> 3
 
-    # Reject overlong or otherwise non-canonical key varints that decode to the same integer.
-    if elem(Varint.encode(key), 0) != key_bytes do
+    # Reject overlong key varints: an LEB128 encoding is canonical iff its last
+    # byte (the highest 7-bit group) is non-zero, or the varint is a single byte.
+    if key_size > 1 and key >>> (7 * (key_size - 1)) == 0 do
       raise Protox.DecodingError.new(bytes, "invalid key varint")
     end
 

--- a/lib/protox/decode.ex
+++ b/lib/protox/decode.ex
@@ -18,6 +18,10 @@ defmodule Protox.Decode do
 
   @compile {:inline,
             parse_delimited: 2,
+            truncate_unsigned32: 1,
+            truncate_unsigned64: 1,
+            truncate_signed32: 1,
+            truncate_signed64: 1,
             parse_bool: 1,
             parse_sint32: 1,
             parse_sint64: 1,
@@ -161,50 +165,60 @@ defmodule Protox.Decode do
   @spec parse_sint32(binary()) :: {integer(), binary()}
   def parse_sint32(bytes) do
     {value, rest} = Varint.decode(bytes)
-    <<res::unsigned-native-32>> = <<value::unsigned-native-32>>
-    {Zigzag.decode(res), rest}
+    {Zigzag.decode(truncate_unsigned32(value)), rest}
   end
 
   @spec parse_sint64(binary()) :: {integer(), binary()}
   def parse_sint64(bytes) do
     {value, rest} = Varint.decode(bytes)
-    <<res::unsigned-native-64>> = <<value::unsigned-native-64>>
-    {Zigzag.decode(res), rest}
+    {Zigzag.decode(truncate_unsigned64(value)), rest}
   end
 
   @spec parse_uint32(binary()) :: {non_neg_integer(), binary()}
   def parse_uint32(bytes) do
     {value, rest} = Varint.decode(bytes)
-    <<res::unsigned-native-32>> = <<value::unsigned-native-32>>
-    {res, rest}
+    {truncate_unsigned32(value), rest}
   end
 
   @spec parse_uint64(binary()) :: {non_neg_integer(), binary()}
   def parse_uint64(bytes) do
     {value, rest} = Varint.decode(bytes)
-    <<res::unsigned-native-64>> = <<value::unsigned-native-64>>
-    {res, rest}
+    {truncate_unsigned64(value), rest}
   end
 
   @spec parse_enum(binary(), module()) :: {atom() | integer(), binary()}
   def parse_enum(bytes, mod) do
     {value, rest} = Varint.decode(bytes)
-    <<res::signed-native-32>> = <<value::signed-native-32>>
-    {mod.decode(res), rest}
+    {mod.decode(truncate_signed32(value)), rest}
   end
 
   @spec parse_int32(binary()) :: {integer(), binary()}
   def parse_int32(bytes) do
     {value, rest} = Varint.decode(bytes)
-    <<res::signed-native-32>> = <<value::signed-native-32>>
-    {res, rest}
+    {truncate_signed32(value), rest}
   end
 
   @spec parse_int64(binary()) :: {integer(), binary()}
   def parse_int64(bytes) do
     {value, rest} = Varint.decode(bytes)
-    <<res::signed-native-64>> = <<value::signed-native-64>>
-    {res, rest}
+    {truncate_signed64(value), rest}
+  end
+
+  defp truncate_unsigned32(value), do: value &&& 0xFFFF_FFFF
+  defp truncate_unsigned64(value), do: value &&& 0xFFFF_FFFF_FFFF_FFFF
+
+  defp truncate_signed32(value) do
+    case value &&& 0xFFFF_FFFF do
+      truncated when truncated >= 0x8000_0000 -> truncated - 0x1_0000_0000
+      truncated -> truncated
+    end
+  end
+
+  defp truncate_signed64(value) do
+    case value &&& 0xFFFF_FFFF_FFFF_FFFF do
+      truncated when truncated >= 0x8000_0000_0000_0000 -> truncated - 0x1_0000_0000_0000_0000
+      truncated -> truncated
+    end
   end
 
   @spec validate_string!(binary()) :: binary() | no_return()

--- a/lib/protox/define_decoder.ex
+++ b/lib/protox/define_decoder.ex
@@ -178,27 +178,19 @@ defmodule Protox.DefineDecoder do
     parse_single = make_parse_single(vars.bytes, field.type)
     update_field = make_update_field(vars.value, field, vars, _wrap_value = true)
 
-    key_bytes = make_key_bytes(field)
-
-    # The last 3 bits of the first byte are the wire type, which we can to ignore here as we know beforehand
-    # how the field is encoded.
-    <<first_byte::5, _wire_type::3, tail::binary>> = key_bytes
-
-    clause =
-      case tail do
-        "" ->
-          quote do
-            <<unquote(first_byte)::5, _wire_type::3, unquote(vars.bytes)::binary>>
-          end
-
-        _key_tail ->
-          quote do
-            <<unquote(first_byte)::5, _wire_type::3, unquote(tail), unquote(vars.bytes)::binary>>
-          end
-      end
+    # Match the full literal key (tag and wire type): the BEAM can then dispatch
+    # on whole bytes, and a known tag with an unexpected wire type falls through
+    # to the unknown-field clause instead of being misparsed. The wire type comes
+    # from the element type, not the field kind: for repeated fields this clause
+    # decodes single (unpacked) occurrences, whose key differs from the packed one.
+    key_bytes =
+      field.tag
+      |> Protox.Encode.make_key_bytes(field.type)
+      |> elem(0)
+      |> IO.iodata_to_binary()
 
     quote do
-      unquote(clause) ->
+      <<unquote(key_bytes), unquote(vars.bytes)::binary>> ->
         {value, rest} = unquote(parse_single)
         {unquote(update_field), rest}
     end
@@ -242,31 +234,14 @@ defmodule Protox.DefineDecoder do
         make_update_field(parse_delimited, field, vars, _wrap_value = !single_generated)
       end
 
-    key_bytes = make_key_bytes(%{field | kind: :packed})
-
-    clause =
-      if single_generated do
-        quote do
-          <<unquote(key_bytes), unquote(vars.bytes)::binary>>
-        end
-      else
-        <<first_byte::5, _wire_type::3, tail::binary>> = key_bytes
-
-        case tail do
-          "" ->
-            quote do
-              <<unquote(first_byte)::5, unquote(@wire_delimited)::3, unquote(vars.bytes)::binary>>
-            end
-
-          _key_tail ->
-            quote do
-              <<unquote(first_byte)::5, unquote(@wire_delimited)::3, unquote(tail), unquote(vars.bytes)::binary>>
-            end
-        end
-      end
+    key_bytes =
+      field.tag
+      |> Protox.Encode.make_key_bytes(:packed)
+      |> elem(0)
+      |> IO.iodata_to_binary()
 
     quote do
-      unquote(clause) ->
+      <<unquote(key_bytes), unquote(vars.bytes)::binary>> ->
         {len, unquote(vars.bytes)} = Protox.Varint.decode(unquote(vars.bytes))
 
         {unquote(vars.delimited), rest} = Protox.Decode.parse_delimited(unquote(vars.bytes), len)
@@ -596,24 +571,6 @@ defmodule Protox.DefineDecoder do
       {:message, _msg_type} -> parse_delimited
       _scalar_type -> make_parse_single(vars.rest, type)
     end
-  end
-
-  # Compute at compile time the varint representation of a field tag and wire type.
-  defp make_key_bytes(%Field{} = field) do
-    # We need to convert the type to something recognized
-    # by Protox.Encode.make_key_bytes/2.
-    ty =
-      case field.kind do
-        :map -> :map_entry
-        :packed -> :packed
-        _other_kind -> field.type
-      end
-
-    key_bytes_and_size = Protox.Encode.make_key_bytes(field.tag, ty)
-
-    key_bytes_and_size
-    |> elem(0)
-    |> IO.iodata_to_binary()
   end
 
   defp maybe_wrap(value, true = _wrap_value), do: [value]

--- a/lib/protox/define_decoder.ex
+++ b/lib/protox/define_decoder.ex
@@ -10,7 +10,6 @@ defmodule Protox.DefineDecoder do
     vars = %{
       bytes: Macro.var(:bytes, __MODULE__),
       delimited: Macro.var(:delimited, __MODULE__),
-      field: Macro.var(:field, __MODULE__),
       msg: Macro.var(:msg, __MODULE__),
       rest: Macro.var(:rest, __MODULE__),
       set_fields: Macro.var(:set_fields, __MODULE__),
@@ -116,10 +115,9 @@ defmodule Protox.DefineDecoder do
     # This has the benefit of a small speedup (~1%-10%) and a decrease in memory usage (~10%) from
     # the Varint.decode version.
     quote do
-      {unquote(vars.field), rest} =
+      {msg_updated, rest} =
         case bytes, do: unquote(all_clauses)
 
-      msg_updated = struct(unquote(vars.msg), unquote(vars.field))
       parse_key_value(rest, msg_updated)
     end
   end
@@ -158,20 +156,17 @@ defmodule Protox.DefineDecoder do
   end
 
   defp make_parse_key_value_unknown(vars, unknown_fields_name) do
-    body =
-      quote do
-        {
-          unquote(unknown_fields_name),
-          [unquote(vars.value) | unquote(vars.msg).unquote(unknown_fields_name)]
-        }
-      end
-
     quote do
       <<unquote(vars.bytes)::binary>> ->
         {tag, wire_type, rest} = Protox.Decode.parse_key(unquote(vars.bytes))
         {unquote(vars.value), rest} = Protox.Decode.parse_unknown(tag, wire_type, rest)
 
-        {[unquote(body)], rest}
+        {%{
+           unquote(vars.msg)
+           | unquote(unknown_fields_name) => [
+               unquote(vars.value) | unquote(vars.msg).unquote(unknown_fields_name)
+             ]
+         }, rest}
     end
   end
 
@@ -205,7 +200,7 @@ defmodule Protox.DefineDecoder do
     quote do
       unquote(clause) ->
         {value, rest} = unquote(parse_single)
-        {[unquote(update_field)], rest}
+        {unquote(update_field), rest}
     end
   end
 
@@ -275,7 +270,7 @@ defmodule Protox.DefineDecoder do
         {len, unquote(vars.bytes)} = Protox.Varint.decode(unquote(vars.bytes))
 
         {unquote(vars.delimited), rest} = Protox.Decode.parse_delimited(unquote(vars.bytes), len)
-        {[unquote(update_field)], rest}
+        {unquote(update_field), rest}
     end
   end
 
@@ -283,7 +278,10 @@ defmodule Protox.DefineDecoder do
     quote do
       {entry_key, entry_value} = unquote(value)
 
-      {unquote(field.name), Map.put(unquote(vars.msg).unquote(field.name), entry_key, entry_value)}
+      %{
+        unquote(vars.msg)
+        | unquote(field.name) => Map.put(unquote(vars.msg).unquote(field.name), entry_key, entry_value)
+      }
     end
   end
 
@@ -293,44 +291,47 @@ defmodule Protox.DefineDecoder do
         quote do
           # It's unclear if we should merge the value here or not. For now, conformance tests
           # pass without this.
-          {unquote(field.name), unquote(value)}
+          %{unquote(vars.msg) | unquote(field.name) => unquote(value)}
         end
 
       _other_label ->
         quote do
           case unquote(vars.msg).unquote(field.kind.parent) do
             {unquote(field.name), previous_value} ->
-              {unquote(field.kind.parent),
-               {unquote(field.name), Protox.MergeMessage.merge(previous_value, unquote(value))}}
+              %{
+                unquote(vars.msg)
+                | unquote(field.kind.parent) =>
+                    {unquote(field.name), Protox.MergeMessage.merge(previous_value, unquote(value))}
+              }
 
             _no_previous ->
-              {unquote(field.kind.parent), {unquote(field.name), unquote(value)}}
+              %{unquote(vars.msg) | unquote(field.kind.parent) => {unquote(field.name), unquote(value)}}
           end
         end
     end
   end
 
-  defp make_update_field(value, %Field{kind: %OneOf{}} = field, _vars, _wrap_value) do
+  defp make_update_field(value, %Field{kind: %OneOf{}} = field, vars, _wrap_value) do
     case field.label do
       :proto3_optional ->
-        quote(do: {unquote(field.name), unquote(value)})
+        quote(do: %{unquote(vars.msg) | unquote(field.name) => unquote(value)})
 
       _other_label ->
-        quote(do: {unquote(field.kind.parent), {unquote(field.name), unquote(value)}})
+        quote(do: %{unquote(vars.msg) | unquote(field.kind.parent) => {unquote(field.name), unquote(value)}})
     end
   end
 
   defp make_update_field(value, %Field{kind: %Scalar{}, type: {:message, _msg_type}} = field, vars, _wrap_value) do
     quote do
-      {
-        unquote(field.name),
-        Protox.MergeMessage.merge(unquote(vars.msg).unquote(field.name), unquote(value))
+      %{
+        unquote(vars.msg)
+        | unquote(field.name) => Protox.MergeMessage.merge(unquote(vars.msg).unquote(field.name), unquote(value))
       }
     end
   end
 
-  defp make_update_field(value, %Field{kind: %Scalar{}} = field, _vars, _wrap_value) do
-    quote(do: {unquote(field.name), unquote(value)})
+  defp make_update_field(value, %Field{kind: %Scalar{}} = field, vars, _wrap_value) do
+    quote(do: %{unquote(vars.msg) | unquote(field.name) => unquote(value)})
   end
 
   defp make_update_field(value, %Field{kind: kind} = field, vars, wrap_value) when kind in [:packed, :unpacked] do
@@ -342,7 +343,7 @@ defmodule Protox.DefineDecoder do
       end
 
     quote do
-      {unquote(field.name), unquote(update_value)}
+      %{unquote(vars.msg) | unquote(field.name) => unquote(update_value)}
     end
   end
 
@@ -350,7 +351,7 @@ defmodule Protox.DefineDecoder do
     value = maybe_wrap(value, wrap_value)
 
     quote do
-      {unquote(field.name), unquote(vars.msg).unquote(field.name) ++ unquote(value)}
+      %{unquote(vars.msg) | unquote(field.name) => unquote(vars.msg).unquote(field.name) ++ unquote(value)}
     end
   end
 

--- a/lib/protox/string.ex
+++ b/lib/protox/string.ex
@@ -13,11 +13,11 @@ defmodule Protox.String do
   @spec validate(binary()) :: :ok | {:error, :invalid_utf8 | :too_large}
   def validate(bytes) do
     cond do
-      not String.valid?(bytes) ->
-        {:error, :invalid_utf8}
-
       byte_size(bytes) > @max_size ->
         {:error, :too_large}
+
+      not String.valid?(bytes) ->
+        {:error, :invalid_utf8}
 
       true ->
         :ok

--- a/lib/protox/varint.ex
+++ b/lib/protox/varint.ex
@@ -37,21 +37,21 @@ defmodule Protox.Varint do
   @spec decode(binary) :: {non_neg_integer, binary}
   def decode(<<0::1, byte0::7, rest::binary>>), do: {byte0, rest}
 
-  def decode(<<1::1, byte1::7, 0::1, byte0::7, rest::binary>>), do: {byte1 <<< 0 ||| byte0 <<< 7, rest}
+  def decode(<<1::1, byte1::7, 0::1, byte0::7, rest::binary>>), do: {byte1 ||| byte0 <<< 7, rest}
 
   def decode(<<1::1, byte2::7, 1::1, byte1::7, 0::1, byte0::7, rest::binary>>),
-    do: {byte2 <<< 0 ||| byte1 <<< 7 ||| byte0 <<< 14, rest}
+    do: {byte2 ||| byte1 <<< 7 ||| byte0 <<< 14, rest}
 
   def decode(<<1::1, byte3::7, 1::1, byte2::7, 1::1, byte1::7, 0::1, byte0::7, rest::binary>>),
-    do: {byte3 <<< 0 ||| byte2 <<< 7 ||| byte1 <<< 14 ||| byte0 <<< 21, rest}
+    do: {byte3 ||| byte2 <<< 7 ||| byte1 <<< 14 ||| byte0 <<< 21, rest}
 
   def decode(<<1::1, byte4::7, 1::1, byte3::7, 1::1, byte2::7, 1::1, byte1::7, 0::1, byte0::7, rest::binary>>),
-    do: {byte4 <<< 0 ||| byte3 <<< 7 ||| byte2 <<< 14 ||| byte1 <<< 21 ||| byte0 <<< 28, rest}
+    do: {byte4 ||| byte3 <<< 7 ||| byte2 <<< 14 ||| byte1 <<< 21 ||| byte0 <<< 28, rest}
 
   def decode(
         <<1::1, byte5::7, 1::1, byte4::7, 1::1, byte3::7, 1::1, byte2::7, 1::1, byte1::7, 0::1, byte0::7, rest::binary>>
       ) do
-    {byte5 <<< 0 ||| byte4 <<< 7 ||| byte3 <<< 14 ||| byte2 <<< 21 ||| byte1 <<< 28 ||| byte0 <<< 35, rest}
+    {byte5 ||| byte4 <<< 7 ||| byte3 <<< 14 ||| byte2 <<< 21 ||| byte1 <<< 28 ||| byte0 <<< 35, rest}
   end
 
   def decode(
@@ -59,16 +59,16 @@ defmodule Protox.Varint do
           byte0::7, rest::binary>>
       ),
       do:
-        {byte6 <<< 0 ||| byte5 <<< 7 ||| byte4 <<< 14 ||| byte3 <<< 21 ||| byte2 <<< 28 ||| byte1 <<< 35 |||
-           byte0 <<< 42, rest}
+        {byte6 ||| byte5 <<< 7 ||| byte4 <<< 14 ||| byte3 <<< 21 ||| byte2 <<< 28 ||| byte1 <<< 35 ||| byte0 <<< 42,
+         rest}
 
   def decode(
         <<1::1, byte7::7, 1::1, byte6::7, 1::1, byte5::7, 1::1, byte4::7, 1::1, byte3::7, 1::1, byte2::7, 1::1,
           byte1::7, 0::1, byte0::7, rest::binary>>
       ),
       do:
-        {byte7 <<< 0 ||| byte6 <<< 7 ||| byte5 <<< 14 ||| byte4 <<< 21 ||| byte3 <<< 28 ||| byte2 <<< 35 |||
-           byte1 <<< 42 ||| byte0 <<< 49, rest}
+        {byte7 ||| byte6 <<< 7 ||| byte5 <<< 14 ||| byte4 <<< 21 ||| byte3 <<< 28 ||| byte2 <<< 35 ||| byte1 <<< 42 |||
+           byte0 <<< 49, rest}
 
   def decode(b), do: do_decode(0, 0, b)
 

--- a/test/protox/decode_optimizations_test.exs
+++ b/test/protox/decode_optimizations_test.exs
@@ -1,0 +1,91 @@
+defmodule Protox.DecodeOptimizationsTest do
+  use ExUnit.Case, async: true
+
+  import Bitwise
+
+  alias ProtobufTestMessages.Proto3.TestAllTypesProto3
+
+  describe "known tag with an unexpected wire type" do
+    test "is kept as an unknown field instead of being misparsed" do
+      # optional_int32 has tag 1 and varint wire type; encode it with the
+      # 32-bit wire type (key byte 13) instead.
+      bytes = <<13, 1, 2, 3, 4>>
+      msg = TestAllTypesProto3.decode!(bytes)
+
+      assert msg.optional_int32 == 0
+      assert TestAllTypesProto3.unknown_fields(msg) == [{1, 5, <<1, 2, 3, 4>>}]
+    end
+
+    test "does not prevent decoding subsequent known fields" do
+      bytes = <<13, 1, 2, 3, 4, 8, 42>>
+      msg = TestAllTypesProto3.decode!(bytes)
+
+      assert msg.optional_int32 == 42
+      assert TestAllTypesProto3.unknown_fields(msg) == [{1, 5, <<1, 2, 3, 4>>}]
+    end
+  end
+
+  describe "packed fixed-width fast path" do
+    test "decodes element counts around the four-element unroll boundary" do
+      for count <- 1..9 do
+        values = Enum.to_list(1..count)
+        bytes = for v <- values, into: <<>>, do: <<v::unsigned-little-32>>
+
+        assert Protox.Decode.parse_repeated_fixed32([], bytes) == values
+      end
+    end
+
+    test "decodes NaN and infinities interleaved with finite packed doubles" do
+      values = [1.0, :nan, 2.0, 3.0, 4.0, 5.0, :infinity, :"-infinity", 6.0]
+
+      bytes =
+        for v <- values, into: <<>> do
+          v
+          |> Protox.Encode.encode_double()
+          |> elem(0)
+          |> IO.iodata_to_binary()
+        end
+
+      assert Protox.Decode.parse_repeated_double([], bytes) == values
+    end
+
+    test "raises on a truncated packed fixed32 payload" do
+      assert_raise Protox.DecodingError, fn ->
+        Protox.Decode.parse_repeated_fixed32([], <<1, 2, 3>>)
+      end
+    end
+  end
+
+  describe "varint scalar truncation boundaries" do
+    test "int32 sign boundaries" do
+      # -1 as an int32 arrives as a 10-byte varint (2^64 - 1).
+      assert decode_int32((1 <<< 64) - 1) == -1
+      assert decode_int32(0x7FFF_FFFF) == 2_147_483_647
+      assert decode_int32(0x8000_0000) == -2_147_483_648
+    end
+
+    test "uint32 wraps values above 2^32" do
+      assert decode_uint32((1 <<< 32) + 5) == 5
+      assert decode_uint32((1 <<< 32) - 1) == 4_294_967_295
+    end
+
+    test "int64 sign boundaries" do
+      assert decode_int64((1 <<< 63) - 1) == 9_223_372_036_854_775_807
+      assert decode_int64(1 <<< 63) == -9_223_372_036_854_775_808
+    end
+  end
+
+  defp decode_int32(varint_value), do: decode_with(&Protox.Decode.parse_int32/1, varint_value)
+  defp decode_int64(varint_value), do: decode_with(&Protox.Decode.parse_int64/1, varint_value)
+  defp decode_uint32(varint_value), do: decode_with(&Protox.Decode.parse_uint32/1, varint_value)
+
+  defp decode_with(parse_fun, varint_value) do
+    {value, <<>>} =
+      varint_value
+      |> Protox.Varint.encode()
+      |> elem(0)
+      |> parse_fun.()
+
+    value
+  end
+end


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of malformed, truncated, and non-canonical encoded data.
  * Corrected unknown-field processing when wire types do not match.
  * Oversized strings now report size-limit errors before UTF-8 validation.
  * Improved signed and unsigned integer decoding at boundary values.

* **Performance**
  * Accelerated decoding of repeated fixed-width and floating-point values.
  * Streamlined message decoding and variable-length integer processing.
  * Preserved correct fallback behavior for special floating-point values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->



<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR optimizes Protocol Buffers binary decoding while tightening malformed-input behavior.
- Dispatches generated decoder clauses using complete field keys and updates message structs directly.
- Unrolls packed fixed-width and floating-point decoding in four-value batches.
- Reworks varint truncation, key validation, unknown-field extraction, and delimited-field errors.
- Prioritizes string size-limit errors over UTF-8 validation and adds focused regression coverage.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| lib/protox/decode.ex | Optimizes primitive and repeated-value decoding while preserving malformed-input and special floating-point handling. |
| lib/protox/define_decoder.ex | Generates full-key dispatch clauses and performs direct struct updates for known and unknown fields. |
| lib/protox/string.ex | Checks the protobuf string size limit before UTF-8 validity. |
| lib/protox/varint.ex | Simplifies equivalent bitwise expressions in unrolled varint decoding clauses. |
| test/protox/decode_optimizations_test.exs | Adds regression coverage for wire-type mismatches, packed fixed-width batching, special doubles, truncation, and signed boundaries. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[Encoded protobuf bytes] --> B[Match complete field key]
  B --> C{Known field and wire type?}
  C -->|Yes| D[Decode scalar or delimited value]
  C -->|No| E[Parse and retain unknown field]
  D --> F[Update message struct]
  E --> F
  F --> G{More bytes?}
  G -->|Yes| B
  G -->|No| H[Return decoded message]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["test: pin the new decoder behaviors intr..."](https://github.com/ahamez/protox/commit/e19b863ea24dcd1cc5751df8fc520659a4770167) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57179641)</sub>

<details><summary><h4>Context used (5)</h4></summary>

- Knowledge Base — [Protocol Buffers runtime](https://app.greptile.com/ahamez/-/custom-context/knowledge-base/ahamez/protox/-/docs/protobuf-runtime.md)
- Knowledge Base — [Protocol Buffers decoding](https://app.greptile.com/ahamez/-/custom-context/knowledge-base/ahamez/protox/-/docs/protobuf-decoding.md)
- Knowledge Base — [Wire-format primitives](https://app.greptile.com/ahamez/-/custom-context/knowledge-base/ahamez/protox/-/docs/wire-format-primitives.md)
- Knowledge Base — [Message declaration macros](https://app.greptile.com/ahamez/-/custom-context/knowledge-base/ahamez/protox/-/docs/message-declaration-macros.md)
- Knowledge Base — [Compatibility and validation](https://app.greptile.com/ahamez/-/custom-context/knowledge-base/ahamez/protox/-/docs/compatibility-and-validation.md)
</details>


<!-- /greptile_comment -->