### PR TITLE
Reduce generated code size

### DIFF
--- a/lib/protox/define_encoder.ex
+++ b/lib/protox/define_encoder.ex
@@ -153,26 +153,37 @@ defmodule Protox.DefineEncoder do
     end
   end
 
-  # Cold path, called only after encoding raised an ArgumentError: re-run each
-  # field encoder in isolation, in encoding order, so the error is attributed
-  # to the field that failed originally. Message children are checked through
-  # their own (rescued) encode!/1 so that the attribution points at the
-  # innermost faulty field; scalar oneofs are deliberately not attributed, as
-  # they never were: their bare replay reproduces the original raw error.
+  # Cold path, called only after an encoding error: hands the field encoders
+  # and the message-children modules to Protox.Encode.find_invalid_field!/2,
+  # in encoding order (oneofs first), so the error is attributed to the field
+  # that failed originally.
   defp make_encode_diagnose_fun(oneofs, fields, vars) do
-    oneof_children_diagnoses = Enum.map(oneofs, &make_encode_diagnose_oneof(&1, vars))
+    oneof_entries =
+      Enum.map(oneofs, fn {parent_name, children} ->
+        message_children = for %Field{name: name, type: {:message, mod}} <- children, do: {name, mod}
 
-    entries = Enum.map(fields, &make_encode_diagnose_entry(&1, vars))
+        quote do
+          {:oneof, unquote(parent_name), unquote(make_local_capture(parent_name)), unquote(message_children)}
+        end
+      end)
 
-    if oneof_children_diagnoses == [] and entries == [] do
+    field_entries =
+      Enum.map(fields, fn %Field{name: name} = field ->
+        quote do
+          {unquote(name), unquote(make_local_capture(name)), unquote(message_child_module(field))}
+        end
+      end)
+
+    entries = oneof_entries ++ field_entries
+
+    if entries == [] do
       quote do
         defp encode_diagnose!(_msg), do: :ok
       end
     else
       quote do
         defp encode_diagnose!(%{__struct__: __MODULE__} = unquote(vars.msg)) do
-          unquote_splicing(oneof_children_diagnoses)
-          Protox.Encode.find_invalid_field!(unquote(entries))
+          Protox.Encode.find_invalid_field!(unquote(vars.msg), unquote(entries))
         end
 
         # Not a valid input for this message: no field can be blamed, let the
@@ -182,77 +193,10 @@ defmodule Protox.DefineEncoder do
     end
   end
 
-  defp make_encode_diagnose_oneof({parent_name, children}, vars) do
-    message_children_clauses =
-      Enum.flat_map(children, fn
-        %Field{name: child_name, type: {:message, sub_msg}} ->
-          quote do
-            {unquote(child_name), unquote(vars.child_field_value)} ->
-              Protox.Encode.diagnose_children!(unquote(vars.child_field_value), unquote(sub_msg))
-          end
-
-        _scalar_child ->
-          []
-      end)
-
-    children_diagnosis =
-      if message_children_clauses == [] do
-        []
-      else
-        fallback_clause =
-          quote do
-            _other -> :ok
-          end
-
-        quote_result =
-          quote do
-            case unquote(vars.msg).unquote(parent_name) do
-              unquote(message_children_clauses ++ fallback_clause)
-            end
-          end
-
-        List.wrap(quote_result)
-      end
-
-    replay =
-      quote do
-        try do
-          unquote(make_encode_field_fun_name(parent_name))({[], 0}, unquote(vars.msg))
-        rescue
-          _e in [MatchError, KeyError] ->
-            reraise Protox.EncodingError.new(unquote(parent_name), "invalid field value"),
-                    __STACKTRACE__
-        end
-      end
-
-    quote do
-      (unquote_splicing(children_diagnosis ++ [replay]))
-    end
-  end
-
-  defp make_encode_diagnose_entry(%Field{name: name} = field, vars) do
+  # AST of `&encode_<name>/2`.
+  defp make_local_capture(name) do
     fun_name = make_encode_field_fun_name(name)
-    encode_call = quote(do: unquote(fun_name)({[], 0}, unquote(vars.msg)))
-
-    entry_body =
-      case message_child_module(field) do
-        nil ->
-          encode_call
-
-        child_module ->
-          quote do
-            Protox.Encode.diagnose_children!(
-              unquote(vars.msg).unquote(name),
-              unquote(child_module)
-            )
-
-            unquote(encode_call)
-          end
-      end
-
-    quote do
-      {unquote(name), fn -> unquote(entry_body) end}
-    end
+    {:&, [], [{:/, [], [{fun_name, [], __MODULE__}, 2]}]}
   end
 
   # The module of a field's message children (single, repeated or map values),

--- a/lib/protox/define_encoder.ex
+++ b/lib/protox/define_encoder.ex
@@ -289,11 +289,13 @@ defmodule Protox.DefineEncoder do
           {unquote(vars.acc), unquote(vars.acc_size)}
 
         values ->
-          {packed_bytes, packed_size} = unquote(encode_packed_ast)
+          value_bytes = unquote(encode_packed_ast)
+          value_size = byte_size(value_bytes)
+          {value_size_bytes, value_size_size} = Protox.Varint.encode(value_size)
 
           {
-            [unquote(key_bytes), packed_bytes | unquote(vars.acc)],
-            unquote(vars.acc_size) + unquote(key_size) + packed_size
+            [unquote(key_bytes), value_size_bytes, value_bytes | unquote(vars.acc)],
+            unquote(vars.acc_size) + unquote(key_size) + value_size + value_size_size
           }
       end
     end
@@ -367,55 +369,12 @@ defmodule Protox.DefineEncoder do
     end
   end
 
-  defp make_encode_unknown_fields_fun(vars, opts) do
+  defp make_encode_unknown_fields_fun(_vars, opts) do
     unknown_fields_name = Keyword.fetch!(opts, :unknown_fields_name)
 
     quote do
-      defp encode_unknown_fields({unquote(vars.acc), unquote(vars.acc_size)}, msg) do
-        Enum.reduce(
-          msg.unquote(unknown_fields_name),
-          {unquote(vars.acc), unquote(vars.acc_size)},
-          fn {tag, wire_type, bytes}, {unquote(vars.acc), unquote(vars.acc_size)} ->
-            case wire_type do
-              0 ->
-                {key_bytes, key_size} = Protox.Encode.make_key_bytes(tag, :int32)
-
-                {
-                  [unquote(vars.acc), <<key_bytes::binary, bytes::binary>>],
-                  unquote(vars.acc_size) + key_size + byte_size(bytes)
-                }
-
-              1 ->
-                {key_bytes, key_size} = Protox.Encode.make_key_bytes(tag, :double)
-
-                {
-                  [unquote(vars.acc), <<key_bytes::binary, bytes::binary>>],
-                  unquote(vars.acc_size) + key_size + byte_size(bytes)
-                }
-
-              2 ->
-                {len_bytes, len_size} =
-                  bytes
-                  |> byte_size()
-                  |> Protox.Varint.encode()
-
-                {key_bytes, key_size} = Protox.Encode.make_key_bytes(tag, :packed)
-
-                {
-                  [unquote(vars.acc), <<key_bytes::binary, len_bytes::binary, bytes::binary>>],
-                  unquote(vars.acc_size) + key_size + len_size + byte_size(bytes)
-                }
-
-              5 ->
-                {key_bytes, key_size} = Protox.Encode.make_key_bytes(tag, :float)
-
-                {
-                  [unquote(vars.acc), <<key_bytes::binary, bytes::binary>>],
-                  unquote(vars.acc_size) + key_size + byte_size(bytes)
-                }
-            end
-          end
-        )
+      defp encode_unknown_fields(acc, msg) do
+        Protox.Encode.encode_unknown_fields(acc, msg.unquote(unknown_fields_name))
       end
     end
   end
@@ -442,24 +401,15 @@ defmodule Protox.DefineEncoder do
 
   # Packed elements are appended to a single contiguous binary instead of one
   # binary and one iodata cell per element, with the packed length derived
-  # from byte_size/1.
+  # from byte_size/1 by Protox.Encode.prepend_packed/5.
   defp make_encode_packed_body({:enum, mod}) do
-    make_packed_body_tail(quote(do: Protox.Encode.encode_packed_enum(values, <<>>, &unquote(mod).encode/1)))
+    quote(do: Protox.Encode.encode_packed_enum(values, <<>>, &unquote(mod).encode/1))
   end
 
   defp make_encode_packed_body(type) do
     appender = Map.fetch!(@packed_binary_appenders, type)
 
-    make_packed_body_tail(quote(do: Protox.Encode.unquote(appender)(values, <<>>)))
-  end
-
-  defp make_packed_body_tail(appender_call_ast) do
-    quote do
-      value_bytes = unquote(appender_call_ast)
-      value_size = byte_size(value_bytes)
-      {value_size_bytes, value_size_size} = Protox.Varint.encode(value_size)
-      {[value_size_bytes, value_bytes], value_size + value_size_size}
-    end
+    quote(do: Protox.Encode.unquote(appender)(values, <<>>))
   end
 
   defp make_encode_repeated_body(tag, type) do

--- a/lib/protox/define_message.ex
+++ b/lib/protox/define_message.ex
@@ -49,14 +49,59 @@ defmodule Protox.DefineMessage do
           unquote(unknown_fields_funs)
           unquote(default_fun)
 
-          @spec schema() :: Protox.MessageSchema.t()
-          def schema(), do: unquote(Macro.escape(msg_schema))
+          unquote(make_schema_fun(msg_schema))
         end
       end
     end
   end
 
   # -- Private
+
+  # The schema is emitted in a compact tuple form (far smaller in source form
+  # than the escaped structs) and expanded back at compile time of the
+  # generated module.
+  defp make_schema_fun(msg_schema) do
+    compact_fields = make_compact_fields(msg_schema)
+
+    # The compact form must expand to the exact original schema.
+    ^msg_schema =
+      Protox.MessageSchema.expand!(
+        msg_schema.name,
+        msg_schema.syntax,
+        compact_fields,
+        msg_schema.file_options
+      )
+
+    quote do
+      @schema Protox.MessageSchema.expand!(
+                unquote(msg_schema.name),
+                unquote(msg_schema.syntax),
+                unquote(Macro.escape(compact_fields)),
+                unquote(Macro.escape(msg_schema.file_options))
+              )
+
+      @spec schema() :: Protox.MessageSchema.t()
+      def schema(), do: @schema
+    end
+  end
+
+  defp make_compact_fields(msg_schema) do
+    msg_schema.fields
+    |> Enum.sort()
+    |> Enum.map(fn {name, %Field{} = field} ->
+      kind =
+        case field.kind do
+          %Scalar{default_value: default_value} -> {:scalar, default_value}
+          %OneOf{parent: parent} -> {:oneof, parent}
+          kind when kind in [:map, :packed, :unpacked] -> kind
+        end
+
+      case field.extender do
+        nil -> {name, field.tag, field.label, kind, field.type}
+        extender -> {name, field.tag, field.label, kind, field.type, extender}
+      end
+    end)
+  end
 
   defp make_unknown_fields_funs(unknown_fields) do
     quote do

--- a/lib/protox/define_message.ex
+++ b/lib/protox/define_message.ex
@@ -44,12 +44,13 @@ defmodule Protox.DefineMessage do
           unquote(struct_fields_types)
           defstruct unquote(struct_fields)
 
+          # Defined before the functions that read @schema.
+          unquote(make_schema_fun(msg_schema))
+
           unquote(encoder)
           unquote(decoder)
           unquote(unknown_fields_funs)
           unquote(default_fun)
-
-          unquote(make_schema_fun(msg_schema))
         end
       end
     end
@@ -116,29 +117,13 @@ defmodule Protox.DefineMessage do
     end
   end
 
-  # Generate the functions that provide a direct access to the default value of a field.
-  defp make_default_funs(fields) do
-    all_default_funs =
-      Enum.map(fields, fn
-        %Field{name: name, kind: %Scalar{default_value: default}} ->
-          quote do
-            def default(unquote(name)), do: {:ok, unquote(default)}
-          end
-
-        %Field{name: name} ->
-          quote do
-            def default(unquote(name)), do: {:error, :no_default_value}
-          end
-      end)
-
+  # Generate the function that provides a direct access to the default value of a field.
+  defp make_default_funs(_fields) do
     quote do
       @spec default(atom()) ::
               {:ok, boolean() | integer() | String.t() | float()}
               | {:error, :no_such_field | :no_default_value}
-
-      unquote_splicing(all_default_funs)
-
-      def default(_field_name), do: {:error, :no_such_field}
+      def default(field_name), do: Protox.MessageSchema.default(@schema, field_name)
     end
   end
 

--- a/lib/protox/encode.ex
+++ b/lib/protox/encode.ex
@@ -59,6 +59,50 @@ defmodule Protox.Encode do
     {[size_varint, value], size + byte_size(value)}
   end
 
+  @doc false
+  # Appends the unknown fields, which are kept in their wire format, after all
+  # the known fields. The accumulator tuple is passed through untouched in the
+  # common empty case so it can be reused. An unexpected wire type raises a
+  # CaseClauseError, as it always did.
+  @spec encode_unknown_fields(
+          {iodata(), non_neg_integer()},
+          [{non_neg_integer(), Protox.Types.tag(), binary()}]
+        ) :: {iodata(), non_neg_integer()}
+  def encode_unknown_fields(acc_tuple, []), do: acc_tuple
+
+  def encode_unknown_fields({acc, acc_size}, unknown_fields) do
+    do_encode_unknown_fields(acc, acc_size, unknown_fields)
+  end
+
+  defp do_encode_unknown_fields(acc, acc_size, []), do: {acc, acc_size}
+
+  defp do_encode_unknown_fields(acc, acc_size, [{tag, wire_type, bytes} | rest]) do
+    {key_bytes, key_size} = Varint.encode(tag <<< 3 ||| wire_type)
+
+    {len_prefix_bytes, len_prefix_size} =
+      case wire_type do
+        0 ->
+          {<<>>, 0}
+
+        1 ->
+          {<<>>, 0}
+
+        2 ->
+          bytes
+          |> byte_size()
+          |> Varint.encode()
+
+        5 ->
+          {<<>>, 0}
+      end
+
+    do_encode_unknown_fields(
+      [acc, key_bytes, len_prefix_bytes, bytes],
+      acc_size + key_size + len_prefix_size + byte_size(bytes),
+      rest
+    )
+  end
+
   # Packed elements are appended to a single contiguous binary: amortized O(1)
   # binary append, one reduction per element, and the packed length comes for
   # free from byte_size/1.

--- a/lib/protox/encode.ex
+++ b/lib/protox/encode.ex
@@ -173,21 +173,49 @@ defmodule Protox.Encode do
   end
 
   @doc false
-  # Cold path: runs each field encoder in isolation and raises an EncodingError
-  # naming the first field whose encoder fails. Already-attributed errors pass
-  # through untouched.
-  @spec find_invalid_field!([{atom(), (-> any())}]) :: :ok | no_return()
-  def find_invalid_field!(entries) do
-    Enum.each(entries, fn {name, encode_fun} ->
-      try do
-        encode_fun.()
-      rescue
-        e in [Protox.EncodingError, Protox.RequiredFieldsError] ->
-          reraise e, __STACKTRACE__
+  # Cold path: runs each field encoder in isolation, in encoding order, and
+  # raises an EncodingError naming the first field whose encoder fails.
+  # Already-attributed errors pass through untouched; message children are
+  # diagnosed through their own encode!/1 first so the attribution points at
+  # the innermost faulty field. Oneofs only attribute the wrong-shape errors
+  # of their message children (MatchError/KeyError): an invalid scalar child
+  # keeps raising its raw error, as it always did.
+  @typedoc false
+  @type diagnose_entry() ::
+          {atom(), (any(), struct() -> any()), module() | nil}
+          | {:oneof, atom(), (any(), struct() -> any()), [{atom(), module()}]}
+  @spec find_invalid_field!(struct(), [diagnose_entry()]) :: :ok | no_return()
+  def find_invalid_field!(msg, entries) do
+    Enum.each(entries, fn
+      {:oneof, parent_name, encode_fun, message_children} ->
+        with {child_name, child_value} <- Map.fetch!(msg, parent_name),
+             {_child_name, child_module} <- List.keyfind(message_children, child_name, 0) do
+          diagnose_children!(child_value, child_module)
+        end
 
-        _e ->
-          reraise Protox.EncodingError.new(name, "invalid field value"), __STACKTRACE__
-      end
+        try do
+          encode_fun.({[], 0}, msg)
+        rescue
+          _e in [MatchError, KeyError] ->
+            reraise Protox.EncodingError.new(parent_name, "invalid field value"), __STACKTRACE__
+        end
+
+      {name, encode_fun, child_module} ->
+        try do
+          # Inside the rescue: a nested raw error (e.g. from a scalar oneof of
+          # a child message) is attributed to this field, as it always was.
+          if child_module != nil do
+            diagnose_children!(Map.fetch!(msg, name), child_module)
+          end
+
+          encode_fun.({[], 0}, msg)
+        rescue
+          e in [Protox.EncodingError, Protox.RequiredFieldsError] ->
+            reraise e, __STACKTRACE__
+
+          _e ->
+            reraise Protox.EncodingError.new(name, "invalid field value"), __STACKTRACE__
+        end
     end)
   end
 

--- a/lib/protox/generate.ex
+++ b/lib/protox/generate.ex
@@ -74,8 +74,38 @@ defmodule Protox.Generate do
       "# credo:disable-for-this-file\n",
       code
       |> Macro.to_string()
+      |> fold_trivial_defs()
       |> Code.format_string!(),
       "\n"
     ]
   end
+
+  @max_line_length 98
+
+  # Macro.to_string/1 always renders do/end blocks. Fold the trivial ones
+  # (a def with a single-line body) into the keyword form, which the
+  # formatter preserves: `def default(), do: {:ok, nil}`.
+  defp fold_trivial_defs(code) do
+    code
+    |> String.split("\n")
+    |> fold_trivial_defs([])
+    |> Enum.reverse()
+    |> Enum.join("\n")
+  end
+
+  defp fold_trivial_defs([head, body, tail | rest], acc) do
+    with [_all, indent, definition] <- Regex.run(~r/^(\s*)(defp? .*[^,]) do$/, head),
+         true <- tail == indent <> "end",
+         body = String.trim(body),
+         # Skip bodies that themselves use a block or clause syntax.
+         false <- String.contains?(body, [" do", "do:", "->", "#"]),
+         folded = "#{indent}#{definition}, do: #{body}",
+         true <- String.length(folded) <= @max_line_length do
+      fold_trivial_defs(rest, [folded | acc])
+    else
+      _cannot_fold -> fold_trivial_defs([body, tail | rest], [head | acc])
+    end
+  end
+
+  defp fold_trivial_defs(remaining_lines, acc), do: Enum.reverse(remaining_lines, acc)
 end

--- a/lib/protox/merge_message.ex
+++ b/lib/protox/merge_message.ex
@@ -58,8 +58,7 @@ defmodule Protox.MergeMessage do
       %Field{kind: %Scalar{}, type: {:message, _mod}} ->
         merge(v1, v2)
 
-      %Field{kind: %Scalar{}} ->
-        {:ok, default} = msg.__struct__.default(name)
+      %Field{kind: %Scalar{default_value: default}} ->
         merge_scalar(msg.__struct__.schema().syntax, v1, v2, default)
 
       %Field{kind: :map, type: {_key_type, {:message, _mod}}} ->

--- a/lib/protox/message_schema.ex
+++ b/lib/protox/message_schema.ex
@@ -69,4 +69,22 @@ defmodule Protox.MessageSchema do
   defp expand_kind({:scalar, default_value}), do: %Protox.Scalar{default_value: default_value}
   defp expand_kind({:oneof, parent}), do: %Protox.OneOf{parent: parent}
   defp expand_kind(kind) when kind in [:map, :packed, :unpacked], do: kind
+
+  @doc false
+  # Backs the generated default/1 functions.
+  @spec default(t(), atom()) ::
+          {:ok, boolean() | integer() | String.t() | float() | nil}
+          | {:error, :no_such_field | :no_default_value}
+  def default(%__MODULE__{fields: fields}, field_name) do
+    case fields do
+      %{^field_name => %Protox.Field{kind: %Protox.Scalar{default_value: default_value}}} ->
+        {:ok, default_value}
+
+      %{^field_name => _field} ->
+        {:error, :no_default_value}
+
+      _no_such_field ->
+        {:error, :no_such_field}
+    end
+  end
 end

--- a/lib/protox/message_schema.ex
+++ b/lib/protox/message_schema.ex
@@ -25,4 +25,48 @@ defmodule Protox.MessageSchema do
   @enforced_keys [:name, :syntax, :fields]
   @enforce_keys @enforced_keys
   defstruct @enforced_keys ++ [:file_options]
+
+  @typedoc false
+  @type compact_field() ::
+          {atom(), number(), Protox.Types.label(), compact_kind(), Protox.Types.type()}
+          | {atom(), number(), Protox.Types.label(), compact_kind(), Protox.Types.type(), atom()}
+
+  @typedoc false
+  @type compact_kind() :: {:scalar, any()} | :map | :packed | :unpacked | {:oneof, atom()}
+
+  @doc false
+  # Builds a schema from the compact field representation emitted by the code
+  # generator, which is far smaller in source form than the escaped structs.
+  # Called at compile time of the generated modules (the result is stored in a
+  # module attribute); never on any runtime path.
+  @spec expand!(atom(), atom(), [compact_field()], map() | nil) :: t()
+  def expand!(name, syntax, compact_fields, file_options) do
+    fields =
+      Map.new(compact_fields, fn compact_field ->
+        {field_name, tag, label, compact_kind, type} = five_first_elems(compact_field)
+
+        field = %Protox.Field{
+          tag: tag,
+          label: label,
+          name: field_name,
+          kind: expand_kind(compact_kind),
+          type: type,
+          extender: extender(compact_field)
+        }
+
+        {field_name, field}
+      end)
+
+    %__MODULE__{name: name, syntax: syntax, fields: fields, file_options: file_options}
+  end
+
+  defp five_first_elems({name, tag, label, kind, type}), do: {name, tag, label, kind, type}
+  defp five_first_elems({name, tag, label, kind, type, _extender}), do: {name, tag, label, kind, type}
+
+  defp extender({_name, _tag, _label, _kind, _type, extender}), do: extender
+  defp extender(_five_elems), do: nil
+
+  defp expand_kind({:scalar, default_value}), do: %Protox.Scalar{default_value: default_value}
+  defp expand_kind({:oneof, parent}), do: %Protox.OneOf{parent: parent}
+  defp expand_kind(kind) when kind in [:map, :packed, :unpacked], do: kind
 end

--- a/test/protox/generate_test.exs
+++ b/test/protox/generate_test.exs
@@ -167,5 +167,9 @@ defmodule Protox.GenerateTest do
 
     assert content =~ "repeated_string: :lists.reverse(values)"
     assert content =~ "repeated_bool: :lists.reverse(values)"
+
+    # Trivial defs are folded to the keyword form.
+    assert content =~ "def default(:optional_int32), do: {:ok, 0}\n"
+    refute content =~ ~r/def default\(:optional_int32\) do\n/
   end
 end

--- a/test/protox/generate_test.exs
+++ b/test/protox/generate_test.exs
@@ -169,7 +169,10 @@ defmodule Protox.GenerateTest do
     assert content =~ "repeated_bool: :lists.reverse(values)"
 
     # Trivial defs are folded to the keyword form.
-    assert content =~ "def default(:optional_int32), do: {:ok, 0}\n"
-    refute content =~ ~r/def default\(:optional_int32\) do\n/
+    assert content =~ "def encode(:FOO), do: 0\n"
+    refute content =~ ~r/def encode\(:FOO\) do\n/
+
+    # default/1 is a single schema lookup.
+    assert content =~ "def default(field_name), do: Protox.MessageSchema.default(@schema, field_name)"
   end
 end


### PR DESCRIPTION
Round 4: shrink the generated code without touching wire bytes or public contracts. Reference metric: bytes of `mix protox.generate` output. Gates per step: full-length benchee (reductions+memory, auto-keep both-better / ask on split / revert both-worse), 223-test suite, and compilation time (discard if ≥1.10× slower).

**Result: proto3 reference 341,578 → 288,135 bytes (−15.6%, −19% lines); proto2 twin 497,407 → 417,056 (−16.2%). Encode is also faster: reductions −0.4…−3.5% and memory −0.05…−1.1% vs the round-3 final on all inputs. Compilation got faster too (generation 702→640ms, elixirc 1982→1749ms, best-of-3).**

Kept (one commit each):
- [x] R1 — trivial defs render as one-liners (`def default(), do: {:ok, nil}`), −526 lines
- [x] S1 — `schema()` emitted as compact tuples, expanded at compile time into `@schema` (generator asserts the expansion equals the original), −25.5KB
- [x] S2 — `default/1` is a single schema lookup; `MergeMessage` reads the default from the field it already holds, −9.5KB
- [x] D1 — diagnosis entries as data (`{name, &encode_x/2, child_module}`) handed to `find_invalid_field!/2`; cold path, −7KB
- [x] U2 — shared unknown-fields encoder with pass-through accumulator tuple, −8.4KB and a hot-path win

Measured and rejected (details in commit messages):
- M1 (map-encoder dedup via runtime helpers): threading the field key as a runtime argument regressed the map-bearing input on both metrics (+2.4% reductions / +7.5% memory; an iodata variant still +1.9%/+3.5%) — per-field map encoders are a deliberate perf trade
- P1 (packed length-prefix finisher helper): +0.2–0.6% reductions for ~2KB
- U1 (repeated-field runtime helpers): skipped — same per-element dynamic-key pattern M1 measured as a regression
- A first U2 shape passing `acc`/`acc_size` separately: rebuilding the tuple across the remote-call boundary defeated tuple reuse (+5–9% memory)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR reduces generated Elixir source size by compacting schema metadata, folding trivial definitions, and moving repeated encoding and diagnostic logic into shared runtime helpers.
- Reconstructs exact message schemas from compact field tuples at compile time and uses them for public default lookup.
- Centralizes unknown-field encoding and field-error diagnosis while preserving existing wire framing and attribution behavior.
- Simplifies generated packed-field framing and scalar merge-default access.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| lib/protox/define_encoder.ex | Reduces generated encoder source by emitting diagnostic data and delegating packed and unknown-field framing to shared helpers. |
| lib/protox/encode.ex | Adds shared unknown-field encoding and data-driven invalid-field diagnosis with behavior equivalent to the previous generated implementations. |
| lib/protox/define_message.ex | Emits compact schema tuples, verifies exact round-trip expansion, and implements generated default lookup through the expanded schema. |
| lib/protox/message_schema.ex | Reconstructs complete field metadata from compact tuples and centralizes the existing field-default contract. |
| lib/protox/merge_message.ex | Reads scalar defaults directly from already-matched schema metadata without changing merge semantics. |
| lib/protox/generate.ex | Post-processes generated source to fold eligible three-line definitions into formatter-safe one-line definitions. |
| test/protox/generate_test.exs | Adds generated-source assertions for folded definitions and schema-backed default lookup. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
    P[Parsed MessageSchema] --> C[Compact field tuples]
    C --> G[Generated Elixir source]
    G --> E[Compile-time schema expansion]
    E --> M[Generated message module]
    M --> S[schema and default lookup]
    M --> R[Shared encoding helpers]
```
</details>

<sub>Reviews (5): Last reviewed commit: ["refactor: share the unknown-fields encod..."](https://github.com/ahamez/protox/commit/f6f28db9a2117fc68a153a6c6e6b3a91ccc73ac0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57670964)</sub>

<details><summary><h4>Context used (4)</h4></summary>

- Knowledge Base — [Protocol Buffers code generation](https://app.greptile.com/ahamez/-/custom-context/knowledge-base/ahamez/protox/-/docs/protobuf-code-generation.md)
- Knowledge Base — [Protocol Buffers encoding](https://app.greptile.com/ahamez/-/custom-context/knowledge-base/ahamez/protox/-/docs/protobuf-encoding.md)
- Knowledge Base — [Message schemas and descriptors](https://app.greptile.com/ahamez/-/custom-context/knowledge-base/ahamez/protox/-/docs/message-schemas-and-descriptors.md)
- Knowledge Base — [Message value operations](https://app.greptile.com/ahamez/-/custom-context/knowledge-base/ahamez/protox/-/docs/message-value-operations.md)
</details>


<!-- /greptile_comment -->