### PR TITLE
Address the reviews of #306

### DIFF
--- a/lib/protox/define_message.ex
+++ b/lib/protox/define_message.ex
@@ -121,7 +121,7 @@ defmodule Protox.DefineMessage do
   defp make_default_funs(_fields) do
     quote do
       @spec default(atom()) ::
-              {:ok, boolean() | integer() | String.t() | float()}
+              {:ok, Protox.Scalar.scalar_default_value_type()}
               | {:error, :no_such_field | :no_default_value}
       def default(field_name), do: Protox.MessageSchema.default(@schema, field_name)
     end

--- a/lib/protox/generate.ex
+++ b/lib/protox/generate.ex
@@ -82,10 +82,12 @@ defmodule Protox.Generate do
 
   @max_line_length 98
 
+  @doc false
   # Macro.to_string/1 always renders do/end blocks. Fold the trivial ones
   # (a def with a single-line body) into the keyword form, which the
   # formatter preserves: `def default(), do: {:ok, nil}`.
-  defp fold_trivial_defs(code) do
+  @spec fold_trivial_defs(String.t()) :: String.t()
+  def fold_trivial_defs(code) do
     code
     |> String.split("\n")
     |> fold_trivial_defs([])

--- a/lib/protox/message_schema.ex
+++ b/lib/protox/message_schema.ex
@@ -73,7 +73,7 @@ defmodule Protox.MessageSchema do
   @doc false
   # Backs the generated default/1 functions.
   @spec default(t(), atom()) ::
-          {:ok, boolean() | integer() | String.t() | float() | nil}
+          {:ok, Protox.Scalar.scalar_default_value_type()}
           | {:error, :no_such_field | :no_default_value}
   def default(%__MODULE__{fields: fields}, field_name) do
     case fields do

--- a/test/protox/generate_fold_test.exs
+++ b/test/protox/generate_fold_test.exs
@@ -1,0 +1,56 @@
+defmodule Protox.GenerateFoldTest do
+  use ExUnit.Case, async: true
+
+  import Protox.Generate, only: [fold_trivial_defs: 1]
+
+  test "folds def and defp with a single-line body" do
+    assert fold_trivial_defs("""
+           def default() do
+             {:ok, nil}
+           end
+           defp helper(x) do
+             x + 1
+           end
+           """) == """
+           def default(), do: {:ok, nil}
+           defp helper(x), do: x + 1
+           """
+  end
+
+  test "preserves surrounding lines and indentation" do
+    assert fold_trivial_defs("""
+           defmodule M do
+             def f() do
+               :ok
+             end
+           end
+           """) == """
+           defmodule M do
+             def f(), do: :ok
+           end
+           """
+  end
+
+  test "does not fold bodies that open a block or use clause syntax" do
+    for body <- ["case x do", "if x, do: y", "fn -> x end", ":ok # comment"] do
+      code = "def f() do\n  #{body}\nend\n"
+      assert fold_trivial_defs(code) == code
+    end
+  end
+
+  test "does not fold multi-line bodies" do
+    code = "def f() do\n  x = 1\n  x + 1\nend\n"
+    assert fold_trivial_defs(code) == code
+  end
+
+  test "does not fold beyond the line length limit" do
+    long_body = "{:ok, \"#{String.duplicate("a", 100)}\"}"
+    code = "def f() do\n  #{long_body}\nend\n"
+    assert fold_trivial_defs(code) == code
+  end
+
+  test "does not fold non-def blocks" do
+    code = "if x do\n  :ok\nend\n"
+    assert fold_trivial_defs(code) == code
+  end
+end

--- a/test/protox/message_schema_test.exs
+++ b/test/protox/message_schema_test.exs
@@ -1,0 +1,92 @@
+defmodule Protox.MessageSchemaTest do
+  use ExUnit.Case, async: true
+
+  alias ProtobufTestMessages.Proto3.TestAllTypesProto3
+  alias Protox.{Field, MessageSchema, OneOf, Scalar}
+
+  @compact_fields [
+    {:a, 1, :optional, {:scalar, 0}, :int32},
+    {:b, 2, nil, :map, {:string, :int64}},
+    {:c, 3, :repeated, :packed, :sint32},
+    {:d, 4, :repeated, :unpacked, :string},
+    {:child, 5, :optional, {:oneof, :choice}, :uint32},
+    {:ext, 6, :optional, {:scalar, :FOO}, {:enum, SomeEnum}, SomeExtender}
+  ]
+
+  describe "expand!/4" do
+    test "expands every compact kind, with and without extender" do
+      schema = MessageSchema.expand!(SomeMessage, :proto3, @compact_fields, %{java_package: "x"})
+
+      assert %MessageSchema{
+               name: SomeMessage,
+               syntax: :proto3,
+               file_options: %{java_package: "x"}
+             } = schema
+
+      assert schema.fields == %{
+               a: %Field{tag: 1, label: :optional, name: :a, kind: %Scalar{default_value: 0}, type: :int32},
+               b: %Field{tag: 2, label: nil, name: :b, kind: :map, type: {:string, :int64}},
+               c: %Field{tag: 3, label: :repeated, name: :c, kind: :packed, type: :sint32},
+               d: %Field{tag: 4, label: :repeated, name: :d, kind: :unpacked, type: :string},
+               child: %Field{
+                 tag: 5,
+                 label: :optional,
+                 name: :child,
+                 kind: %OneOf{parent: :choice},
+                 type: :uint32
+               },
+               ext: %Field{
+                 tag: 6,
+                 label: :optional,
+                 name: :ext,
+                 kind: %Scalar{default_value: :FOO},
+                 type: {:enum, SomeEnum},
+                 extender: SomeExtender
+               }
+             }
+    end
+  end
+
+  describe "default/2" do
+    setup do
+      %{schema: MessageSchema.expand!(SomeMessage, :proto3, @compact_fields, nil)}
+    end
+
+    test "scalar fields have a default", %{schema: schema} do
+      assert MessageSchema.default(schema, :a) == {:ok, 0}
+      assert MessageSchema.default(schema, :ext) == {:ok, :FOO}
+    end
+
+    test "map, repeated and oneof fields have no default", %{schema: schema} do
+      assert MessageSchema.default(schema, :b) == {:error, :no_default_value}
+      assert MessageSchema.default(schema, :c) == {:error, :no_default_value}
+      assert MessageSchema.default(schema, :d) == {:error, :no_default_value}
+      assert MessageSchema.default(schema, :child) == {:error, :no_default_value}
+    end
+
+    test "unknown fields are reported", %{schema: schema} do
+      assert MessageSchema.default(schema, :nope) == {:error, :no_such_field}
+    end
+  end
+
+  describe "generated schema/0" do
+    test "expands to the same structs as before the compact representation" do
+      schema = TestAllTypesProto3.schema()
+
+      assert %MessageSchema{name: TestAllTypesProto3, syntax: :proto3} =
+               schema
+
+      assert schema.fields[:optional_int32] ==
+               Protox.Field.new!(
+                 tag: 1,
+                 label: :optional,
+                 name: :optional_int32,
+                 kind: %Scalar{default_value: 0},
+                 type: :int32
+               )
+
+      assert schema.fields[:oneof_uint32].kind == %OneOf{parent: :oneof_field}
+      assert schema.fields[:map_int32_int32].kind == :map
+    end
+  end
+end


### PR DESCRIPTION
Follow-up to #306, which was merged before its review comments were triaged. Addresses all three:

- **Direct tests for the compact schema** (CodeRabbit, major): `Protox.MessageSchema.expand!/4` unit-tested across every compact kind and both tuple arities; `default/2` tested for scalar defaults, no-default kinds, and unknown fields; a generated `schema/0` is pinned against the exact pre-compaction structs.
- **Coverage for every folding branch** (CodeRabbit, minor): `fold_trivial_defs/1` is now a `@doc false` public function, with tests for `def`/`defp`, the block/clause/comment exclusions, multi-line bodies, the line-length limit, and non-`def` blocks.
- **Complete `default` specs** (CodeRabbit, minor): both specs now use `Protox.Scalar.scalar_default_value_type()`, which includes the previously omitted `atom()` and `nil`.

234 tests, credo and dialyzer clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds direct regression coverage for compact message-schema expansion and generated-source folding while correcting the declared return types of default-value APIs.

- Tests every compact field kind, optional extender tuple, default lookup outcome, and representative generated schema metadata.
- Tests folding behavior across public/private definitions, exclusions, indentation, multiline bodies, and line-length limits.
- Exposes the existing folding helper as a documented-internal public function so it can be tested directly.
- Uses the existing comprehensive scalar-default type in both default API specifications.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no concrete functional, compatibility, or security regressions identified.

The production changes preserve existing behavior while correcting typespec coverage and exposing an unchanged pure formatting helper for direct tests; the new tests exercise the intended schema and folding contracts.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| lib/protox/define_message.ex | Replaces an incomplete generated default-function return union with the existing scalar-default type, accurately covering enum atoms and nil message defaults. |
| lib/protox/generate.ex | Makes the unchanged folding helper directly testable and adds an accurate typespec without changing generated-source behavior. |
| lib/protox/message_schema.ex | Aligns the shared default lookup specification with the complete public scalar-default type. |
| test/protox/generate_fold_test.exs | Adds focused coverage for all material folding and exclusion branches. |
| test/protox/message_schema_test.exs | Adds direct compact-schema expansion, default lookup, and generated-schema regression coverage. |

</details>

<sub>Reviews (1): Last reviewed commit: ["test: address the reviews of #306"](https://github.com/ahamez/protox/commit/6bada69845964e34e3ec8a3ca6fd98519d31a60a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57815211)</sub>

<details><summary><h4>Context used (5)</h4></summary>

- Knowledge Base — [Protocol Buffers code generation](https://app.greptile.com/ahamez/-/custom-context/knowledge-base/ahamez/protox/-/docs/protobuf-code-generation.md)
- Knowledge Base — [Message modeling and reflection](https://app.greptile.com/ahamez/-/custom-context/knowledge-base/ahamez/protox/-/docs/message-modeling.md)
- Knowledge Base — [Message declaration macros](https://app.greptile.com/ahamez/-/custom-context/knowledge-base/ahamez/protox/-/docs/message-declaration-macros.md)
- Knowledge Base — [Message schemas and descriptors](https://app.greptile.com/ahamez/-/custom-context/knowledge-base/ahamez/protox/-/docs/message-schemas-and-descriptors.md)
- Knowledge Base — [Message value operations](https://app.greptile.com/ahamez/-/custom-context/knowledge-base/ahamez/protox/-/docs/message-value-operations.md)
</details>


<!-- /greptile_comment -->