### PR TITLE
perf: cut decode-path memory allocations

### DIFF
--- a/lib/protox.ex
+++ b/lib/protox.ex
@@ -182,9 +182,7 @@ defmodule Protox do
     end)
   end
 
-  # 3: parse_repeated_* return the accumulator in reverse wire order instead of
-  #    reversing it themselves; generated code relies on this contract.
-  @generator_version 3
+  @generator_version 2
   @doc nil
   @spec generator_version() :: pos_integer()
   def generator_version(), do: @generator_version

--- a/lib/protox.ex
+++ b/lib/protox.ex
@@ -182,7 +182,9 @@ defmodule Protox do
     end)
   end
 
-  @generator_version 2
+  # 3: parse_repeated_* return the accumulator in reverse wire order instead of
+  #    reversing it themselves; generated code relies on this contract.
+  @generator_version 3
   @doc nil
   @spec generator_version() :: pos_integer()
   def generator_version(), do: @generator_version

--- a/lib/protox/decode.ex
+++ b/lib/protox/decode.ex
@@ -235,8 +235,13 @@ defmodule Protox.Decode do
     end
   end
 
+  # The parse_repeated_* functions prepend the decoded elements onto `acc`, so the
+  # result is in reverse wire order. Callers seed `acc` with the field's current
+  # (also reversed) list and rely on the single reverse in the generated
+  # finish-decode step to restore wire order — reversing here as well would cost
+  # two extra list copies per packed run.
   @spec parse_repeated_bool([boolean()], binary()) :: [boolean()]
-  def parse_repeated_bool(acc, <<>>), do: Enum.reverse(acc)
+  def parse_repeated_bool(acc, <<>>), do: acc
 
   def parse_repeated_bool(acc, bytes) do
     {value, rest} = Protox.Varint.decode(bytes)
@@ -244,7 +249,7 @@ defmodule Protox.Decode do
   end
 
   @spec parse_repeated_enum([atom() | integer()], binary(), module()) :: [atom() | integer()]
-  def parse_repeated_enum(acc, <<>>, _mod), do: Enum.reverse(acc)
+  def parse_repeated_enum(acc, <<>>, _mod), do: acc
 
   def parse_repeated_enum(acc, bytes, mod) do
     {value, rest} = parse_enum(bytes, mod)
@@ -252,7 +257,7 @@ defmodule Protox.Decode do
   end
 
   @spec parse_repeated_int32([integer()], binary()) :: [integer()]
-  def parse_repeated_int32(acc, <<>>), do: Enum.reverse(acc)
+  def parse_repeated_int32(acc, <<>>), do: acc
 
   def parse_repeated_int32(acc, bytes) do
     {value, rest} = parse_int32(bytes)
@@ -260,7 +265,7 @@ defmodule Protox.Decode do
   end
 
   @spec parse_repeated_uint32([non_neg_integer()], binary()) :: [non_neg_integer()]
-  def parse_repeated_uint32(acc, <<>>), do: Enum.reverse(acc)
+  def parse_repeated_uint32(acc, <<>>), do: acc
 
   def parse_repeated_uint32(acc, bytes) do
     {value, rest} = parse_uint32(bytes)
@@ -268,7 +273,7 @@ defmodule Protox.Decode do
   end
 
   @spec parse_repeated_sint32([integer()], binary()) :: [integer()]
-  def parse_repeated_sint32(acc, <<>>), do: Enum.reverse(acc)
+  def parse_repeated_sint32(acc, <<>>), do: acc
 
   def parse_repeated_sint32(acc, bytes) do
     {value, rest} = parse_sint32(bytes)
@@ -276,7 +281,7 @@ defmodule Protox.Decode do
   end
 
   @spec parse_repeated_int64([integer()], binary()) :: [integer()]
-  def parse_repeated_int64(acc, <<>>), do: Enum.reverse(acc)
+  def parse_repeated_int64(acc, <<>>), do: acc
 
   def parse_repeated_int64(acc, bytes) do
     {value, rest} = parse_int64(bytes)
@@ -284,7 +289,7 @@ defmodule Protox.Decode do
   end
 
   @spec parse_repeated_uint64([non_neg_integer()], binary()) :: [non_neg_integer()]
-  def parse_repeated_uint64(acc, <<>>), do: Enum.reverse(acc)
+  def parse_repeated_uint64(acc, <<>>), do: acc
 
   def parse_repeated_uint64(acc, bytes) do
     {value, rest} = parse_uint64(bytes)
@@ -292,7 +297,7 @@ defmodule Protox.Decode do
   end
 
   @spec parse_repeated_sint64([integer()], binary()) :: [integer()]
-  def parse_repeated_sint64(acc, <<>>), do: Enum.reverse(acc)
+  def parse_repeated_sint64(acc, <<>>), do: acc
 
   def parse_repeated_sint64(acc, bytes) do
     {value, rest} = parse_sint64(bytes)
@@ -300,7 +305,7 @@ defmodule Protox.Decode do
   end
 
   @spec parse_repeated_fixed32([non_neg_integer()], binary()) :: [non_neg_integer()]
-  def parse_repeated_fixed32(acc, <<>>), do: Enum.reverse(acc)
+  def parse_repeated_fixed32(acc, <<>>), do: acc
 
   def parse_repeated_fixed32(
         acc,
@@ -315,7 +320,7 @@ defmodule Protox.Decode do
   end
 
   @spec parse_repeated_fixed64([non_neg_integer()], binary()) :: [non_neg_integer()]
-  def parse_repeated_fixed64(acc, <<>>), do: Enum.reverse(acc)
+  def parse_repeated_fixed64(acc, <<>>), do: acc
 
   def parse_repeated_fixed64(
         acc,
@@ -330,7 +335,7 @@ defmodule Protox.Decode do
   end
 
   @spec parse_repeated_sfixed32([integer()], binary()) :: [integer()]
-  def parse_repeated_sfixed32(acc, <<>>), do: Enum.reverse(acc)
+  def parse_repeated_sfixed32(acc, <<>>), do: acc
 
   def parse_repeated_sfixed32(
         acc,
@@ -345,7 +350,7 @@ defmodule Protox.Decode do
   end
 
   @spec parse_repeated_sfixed64([integer()], binary()) :: [integer()]
-  def parse_repeated_sfixed64(acc, <<>>), do: Enum.reverse(acc)
+  def parse_repeated_sfixed64(acc, <<>>), do: acc
 
   def parse_repeated_sfixed64(
         acc,
@@ -362,7 +367,7 @@ defmodule Protox.Decode do
   @spec parse_repeated_float([float() | :infinity | :"-infinity" | :nan], binary()) :: [
           float() | :infinity | :"-infinity" | :nan
         ]
-  def parse_repeated_float(acc, <<>>), do: Enum.reverse(acc)
+  def parse_repeated_float(acc, <<>>), do: acc
 
   # A float segment never matches NaN or infinity payloads: those fall through
   # to the single-element clause below, which handles them.
@@ -381,7 +386,7 @@ defmodule Protox.Decode do
   @spec parse_repeated_double([float() | :infinity | :"-infinity" | :nan], binary()) :: [
           float() | :infinity | :"-infinity" | :nan
         ]
-  def parse_repeated_double(acc, <<>>), do: Enum.reverse(acc)
+  def parse_repeated_double(acc, <<>>), do: acc
 
   # A float segment never matches NaN or infinity payloads: those fall through
   # to the single-element clause below, which handles them.

--- a/lib/protox/decode.ex
+++ b/lib/protox/decode.ex
@@ -13,6 +13,8 @@ defmodule Protox.Decode do
     Zigzag
   }
 
+  alias Protox.Varint.DecodeClauses
+
   # Protobuf keys reserve the low 3 bits for the wire type, leaving 29 bits for the field number.
   @max_field_number (1 <<< 29) - 1
 
@@ -240,8 +242,25 @@ defmodule Protox.Decode do
   # (also reversed) list and rely on the single reverse in the generated
   # finish-decode step to restore wire order — reversing here as well would cost
   # two extra list copies per packed run.
+  #
+  # The varint loops below get one clause per encoded length (1 to 10 bytes).
+  # Matching the varint in the loop's own clause instead of calling the
+  # cross-module Varint.decode/1 avoids a {value, rest} tuple and a sub-binary
+  # per element. Covering all 10 lengths matters: a valid varint falling through
+  # to the closing clause would convert the match context back to a sub-binary
+  # on every element. Only over-long (non-canonical, > 10 bytes) and invalid
+  # trailing bytes take the closing clause, which still uses Varint.decode/1.
+  varint_rest = Macro.var(:rest, __MODULE__)
+  varint_fast_clauses = DecodeClauses.build(1..10, varint_rest)
+
   @spec parse_repeated_bool([boolean()], binary()) :: [boolean()]
   def parse_repeated_bool(acc, <<>>), do: acc
+
+  for {pattern, value} <- varint_fast_clauses do
+    def parse_repeated_bool(acc, unquote(pattern)) do
+      parse_repeated_bool([unquote(value) != 0 | acc], unquote(varint_rest))
+    end
+  end
 
   def parse_repeated_bool(acc, bytes) do
     {value, rest} = Protox.Varint.decode(bytes)
@@ -251,6 +270,12 @@ defmodule Protox.Decode do
   @spec parse_repeated_enum([atom() | integer()], binary(), module()) :: [atom() | integer()]
   def parse_repeated_enum(acc, <<>>, _mod), do: acc
 
+  for {pattern, value} <- varint_fast_clauses do
+    def parse_repeated_enum(acc, unquote(pattern), mod) do
+      parse_repeated_enum([mod.decode(truncate_signed32(unquote(value))) | acc], unquote(varint_rest), mod)
+    end
+  end
+
   def parse_repeated_enum(acc, bytes, mod) do
     {value, rest} = parse_enum(bytes, mod)
     parse_repeated_enum([value | acc], rest, mod)
@@ -258,6 +283,12 @@ defmodule Protox.Decode do
 
   @spec parse_repeated_int32([integer()], binary()) :: [integer()]
   def parse_repeated_int32(acc, <<>>), do: acc
+
+  for {pattern, value} <- varint_fast_clauses do
+    def parse_repeated_int32(acc, unquote(pattern)) do
+      parse_repeated_int32([truncate_signed32(unquote(value)) | acc], unquote(varint_rest))
+    end
+  end
 
   def parse_repeated_int32(acc, bytes) do
     {value, rest} = parse_int32(bytes)
@@ -267,6 +298,12 @@ defmodule Protox.Decode do
   @spec parse_repeated_uint32([non_neg_integer()], binary()) :: [non_neg_integer()]
   def parse_repeated_uint32(acc, <<>>), do: acc
 
+  for {pattern, value} <- varint_fast_clauses do
+    def parse_repeated_uint32(acc, unquote(pattern)) do
+      parse_repeated_uint32([truncate_unsigned32(unquote(value)) | acc], unquote(varint_rest))
+    end
+  end
+
   def parse_repeated_uint32(acc, bytes) do
     {value, rest} = parse_uint32(bytes)
     parse_repeated_uint32([value | acc], rest)
@@ -274,6 +311,12 @@ defmodule Protox.Decode do
 
   @spec parse_repeated_sint32([integer()], binary()) :: [integer()]
   def parse_repeated_sint32(acc, <<>>), do: acc
+
+  for {pattern, value} <- varint_fast_clauses do
+    def parse_repeated_sint32(acc, unquote(pattern)) do
+      parse_repeated_sint32([Zigzag.decode(truncate_unsigned32(unquote(value))) | acc], unquote(varint_rest))
+    end
+  end
 
   def parse_repeated_sint32(acc, bytes) do
     {value, rest} = parse_sint32(bytes)
@@ -283,6 +326,12 @@ defmodule Protox.Decode do
   @spec parse_repeated_int64([integer()], binary()) :: [integer()]
   def parse_repeated_int64(acc, <<>>), do: acc
 
+  for {pattern, value} <- varint_fast_clauses do
+    def parse_repeated_int64(acc, unquote(pattern)) do
+      parse_repeated_int64([truncate_signed64(unquote(value)) | acc], unquote(varint_rest))
+    end
+  end
+
   def parse_repeated_int64(acc, bytes) do
     {value, rest} = parse_int64(bytes)
     parse_repeated_int64([value | acc], rest)
@@ -291,6 +340,12 @@ defmodule Protox.Decode do
   @spec parse_repeated_uint64([non_neg_integer()], binary()) :: [non_neg_integer()]
   def parse_repeated_uint64(acc, <<>>), do: acc
 
+  for {pattern, value} <- varint_fast_clauses do
+    def parse_repeated_uint64(acc, unquote(pattern)) do
+      parse_repeated_uint64([truncate_unsigned64(unquote(value)) | acc], unquote(varint_rest))
+    end
+  end
+
   def parse_repeated_uint64(acc, bytes) do
     {value, rest} = parse_uint64(bytes)
     parse_repeated_uint64([value | acc], rest)
@@ -298,6 +353,12 @@ defmodule Protox.Decode do
 
   @spec parse_repeated_sint64([integer()], binary()) :: [integer()]
   def parse_repeated_sint64(acc, <<>>), do: acc
+
+  for {pattern, value} <- varint_fast_clauses do
+    def parse_repeated_sint64(acc, unquote(pattern)) do
+      parse_repeated_sint64([Zigzag.decode(truncate_unsigned64(unquote(value))) | acc], unquote(varint_rest))
+    end
+  end
 
   def parse_repeated_sint64(acc, bytes) do
     {value, rest} = parse_sint64(bytes)

--- a/lib/protox/define_decoder.ex
+++ b/lib/protox/define_decoder.ex
@@ -222,25 +222,31 @@ defmodule Protox.DefineDecoder do
   # bounds varint_value to 0..127, where every truncation is an identity. That
   # invariant is what makes these transforms sound — extending the fast case
   # beyond one-byte varints would require restoring the truncations.
-  defp make_single_fast_case(vars, %Field{type: type}, key_bytes, update_field) do
-    value =
-      case type do
-        :bool -> quote(do: varint_value != 0)
-        {:enum, mod} -> quote(do: unquote(mod).decode(varint_value))
-        type when type in [:sint32, :sint64] -> quote(do: Protox.Zigzag.decode(varint_value))
-        type when type in [:int32, :int64, :uint32, :uint64] -> quote(do: varint_value)
-        _not_a_varint_type -> nil
-      end
+  defp make_single_fast_case(vars, %Field{type: :bool}, key_bytes, update_field) do
+    make_single_fast_case_clause(vars, key_bytes, update_field, quote(do: varint_value != 0))
+  end
 
-    if value == nil do
-      []
-    else
-      quote do
-        <<unquote(key_bytes), 0::1, varint_value::7, rest::binary>> ->
-          unquote(vars.value) = unquote(value)
-          unquote(vars.msg) = unquote(update_field)
-          parse_key_value(rest, unquote(vars.msg))
-      end
+  defp make_single_fast_case(vars, %Field{type: {:enum, mod}}, key_bytes, update_field) do
+    make_single_fast_case_clause(vars, key_bytes, update_field, quote(do: unquote(mod).decode(varint_value)))
+  end
+
+  defp make_single_fast_case(vars, %Field{type: type}, key_bytes, update_field) when type in [:sint32, :sint64] do
+    make_single_fast_case_clause(vars, key_bytes, update_field, quote(do: Protox.Zigzag.decode(varint_value)))
+  end
+
+  defp make_single_fast_case(vars, %Field{type: type}, key_bytes, update_field)
+       when type in [:int32, :int64, :uint32, :uint64] do
+    make_single_fast_case_clause(vars, key_bytes, update_field, quote(do: varint_value))
+  end
+
+  defp make_single_fast_case(_vars, _field, _key_bytes, _update_field), do: []
+
+  defp make_single_fast_case_clause(vars, key_bytes, update_field, value) do
+    quote do
+      <<unquote(key_bytes), 0::1, varint_value::7, rest::binary>> ->
+        unquote(vars.value) = unquote(value)
+        unquote(vars.msg) = unquote(update_field)
+        parse_key_value(rest, unquote(vars.msg))
     end
   end
 

--- a/lib/protox/define_decoder.ex
+++ b/lib/protox/define_decoder.ex
@@ -130,10 +130,6 @@ defmodule Protox.DefineDecoder do
     # at compile time, we can generate the appropriate clauses.
     # This has the benefit of a small speedup (~1%-10%) and a decrease in memory usage (~10%) from
     # the Varint.decode version.
-    #
-    # Each clause ends with the parse_key_value/2 tail call rather than returning
-    # a {msg, rest} tuple to a shared recursion point: the tuple would cost an
-    # allocation per decoded field.
     quote do
       case bytes, do: unquote(all_clauses)
     end
@@ -204,11 +200,47 @@ defmodule Protox.DefineDecoder do
     # decodes single (unpacked) occurrences, whose key differs from the packed one.
     key_bytes = make_literal_key_bytes(field.tag, field.type)
 
-    quote do
-      <<unquote(key_bytes), unquote(vars.bytes)::binary>> ->
-        {value, rest} = unquote(parse_single)
-        unquote(vars.msg) = unquote(update_field)
-        parse_key_value(rest, unquote(vars.msg))
+    fast_case = make_single_fast_case(vars, field, key_bytes, update_field)
+
+    general_case =
+      quote do
+        <<unquote(key_bytes), unquote(vars.bytes)::binary>> ->
+          {value, rest} = unquote(parse_single)
+          unquote(vars.msg) = unquote(update_field)
+          parse_key_value(rest, unquote(vars.msg))
+      end
+
+    fast_case ++ general_case
+  end
+
+  # For varint-encoded scalars, a clause matching the very common one-byte value
+  # in the key pattern itself skips the Protox.Decode.parse_* call and the
+  # {value, rest} tuple it returns. Larger values fall through to the general
+  # clause right after.
+  #
+  # Unlike the general path, no truncate_* step is applied: the one-byte pattern
+  # bounds varint_value to 0..127, where every truncation is an identity. That
+  # invariant is what makes these transforms sound — extending the fast case
+  # beyond one-byte varints would require restoring the truncations.
+  defp make_single_fast_case(vars, %Field{type: type}, key_bytes, update_field) do
+    value =
+      case type do
+        :bool -> quote(do: varint_value != 0)
+        {:enum, mod} -> quote(do: unquote(mod).decode(varint_value))
+        type when type in [:sint32, :sint64] -> quote(do: Protox.Zigzag.decode(varint_value))
+        type when type in [:int32, :int64, :uint32, :uint64] -> quote(do: varint_value)
+        _not_a_varint_type -> nil
+      end
+
+    if value == nil do
+      []
+    else
+      quote do
+        <<unquote(key_bytes), 0::1, varint_value::7, rest::binary>> ->
+          unquote(vars.value) = unquote(value)
+          unquote(vars.msg) = unquote(update_field)
+          parse_key_value(rest, unquote(vars.msg))
+      end
     end
   end
 
@@ -262,6 +294,9 @@ defmodule Protox.DefineDecoder do
 
     key_bytes = make_literal_key_bytes(field.tag, :packed)
 
+    # No one-byte-length fast clause here: its dynamic binary-size(len) segment
+    # would defeat the shared match tree of the surrounding case, which measurably
+    # blows up decoding of messages with many fields.
     quote do
       <<unquote(key_bytes), unquote(vars.bytes)::binary>> ->
         {len, unquote(vars.bytes)} = Protox.Varint.decode(unquote(vars.bytes))

--- a/lib/protox/define_decoder.ex
+++ b/lib/protox/define_decoder.ex
@@ -246,7 +246,17 @@ defmodule Protox.DefineDecoder do
       if field.type == :bytes do
         make_update_field(vars.delimited, field, vars, _wrap_value = !single_generated)
       else
-        parse_delimited = make_parse_delimited(vars.delimited, field.type)
+        # A generated single case means this delimited case decodes a packed run of
+        # scalars: seed the parse_repeated_* accumulator with the field's current
+        # (reversed) list so the run is prepended onto it directly.
+        acc =
+          if single_generated do
+            quote(do: unquote(vars.msg).unquote(field.name))
+          else
+            quote(do: [])
+          end
+
+        parse_delimited = make_parse_delimited(vars.delimited, acc, field.type)
         make_update_field(parse_delimited, field, vars, _wrap_value = !single_generated)
       end
 
@@ -328,11 +338,14 @@ defmodule Protox.DefineDecoder do
   end
 
   defp make_update_field(value, %Field{kind: kind} = field, vars, wrap_value) when kind in [:packed, :unpacked] do
+    # When wrap_value is false, value is a parse_repeated_* call already seeded
+    # with the field's current list: it returns the full new (reversed)
+    # accumulator, so it's stored as is.
     update_value =
       if wrap_value do
         quote(do: [unquote(value) | unquote(vars.msg).unquote(field.name)])
       else
-        quote(do: Enum.reverse(unquote(value), unquote(vars.msg).unquote(field.name)))
+        value
       end
 
     quote do
@@ -348,75 +361,75 @@ defmodule Protox.DefineDecoder do
     end
   end
 
-  defp make_parse_delimited(bytes_var, :bytes) do
+  defp make_parse_delimited(bytes_var, _acc, :bytes) do
     quote(do: unquote(bytes_var))
   end
 
-  defp make_parse_delimited(bytes_var, :string) do
+  defp make_parse_delimited(bytes_var, _acc, :string) do
     quote(do: Protox.Decode.validate_string!(unquote(bytes_var)))
   end
 
-  defp make_parse_delimited(bytes_var, {:enum, mod}) do
-    quote(do: Protox.Decode.parse_repeated_enum([], unquote(bytes_var), unquote(mod)))
+  defp make_parse_delimited(bytes_var, acc, {:enum, mod}) do
+    quote(do: Protox.Decode.parse_repeated_enum(unquote(acc), unquote(bytes_var), unquote(mod)))
   end
 
-  defp make_parse_delimited(bytes_var, {:message, mod}) do
+  defp make_parse_delimited(bytes_var, _acc, {:message, mod}) do
     quote(do: unquote(mod).decode!(unquote(bytes_var)))
   end
 
-  defp make_parse_delimited(bytes_var, :bool) do
-    quote(do: Protox.Decode.parse_repeated_bool([], unquote(bytes_var)))
+  defp make_parse_delimited(bytes_var, acc, :bool) do
+    quote(do: Protox.Decode.parse_repeated_bool(unquote(acc), unquote(bytes_var)))
   end
 
-  defp make_parse_delimited(bytes_var, :int32) do
-    quote(do: Protox.Decode.parse_repeated_int32([], unquote(bytes_var)))
+  defp make_parse_delimited(bytes_var, acc, :int32) do
+    quote(do: Protox.Decode.parse_repeated_int32(unquote(acc), unquote(bytes_var)))
   end
 
-  defp make_parse_delimited(bytes_var, :uint32) do
-    quote(do: Protox.Decode.parse_repeated_uint32([], unquote(bytes_var)))
+  defp make_parse_delimited(bytes_var, acc, :uint32) do
+    quote(do: Protox.Decode.parse_repeated_uint32(unquote(acc), unquote(bytes_var)))
   end
 
-  defp make_parse_delimited(bytes_var, :sint32) do
-    quote(do: Protox.Decode.parse_repeated_sint32([], unquote(bytes_var)))
+  defp make_parse_delimited(bytes_var, acc, :sint32) do
+    quote(do: Protox.Decode.parse_repeated_sint32(unquote(acc), unquote(bytes_var)))
   end
 
-  defp make_parse_delimited(bytes_var, :int64) do
-    quote(do: Protox.Decode.parse_repeated_int64([], unquote(bytes_var)))
+  defp make_parse_delimited(bytes_var, acc, :int64) do
+    quote(do: Protox.Decode.parse_repeated_int64(unquote(acc), unquote(bytes_var)))
   end
 
-  defp make_parse_delimited(bytes_var, :uint64) do
-    quote(do: Protox.Decode.parse_repeated_uint64([], unquote(bytes_var)))
+  defp make_parse_delimited(bytes_var, acc, :uint64) do
+    quote(do: Protox.Decode.parse_repeated_uint64(unquote(acc), unquote(bytes_var)))
   end
 
-  defp make_parse_delimited(bytes_var, :sint64) do
-    quote(do: Protox.Decode.parse_repeated_sint64([], unquote(bytes_var)))
+  defp make_parse_delimited(bytes_var, acc, :sint64) do
+    quote(do: Protox.Decode.parse_repeated_sint64(unquote(acc), unquote(bytes_var)))
   end
 
-  defp make_parse_delimited(bytes_var, :fixed32) do
-    quote(do: Protox.Decode.parse_repeated_fixed32([], unquote(bytes_var)))
+  defp make_parse_delimited(bytes_var, acc, :fixed32) do
+    quote(do: Protox.Decode.parse_repeated_fixed32(unquote(acc), unquote(bytes_var)))
   end
 
-  defp make_parse_delimited(bytes_var, :fixed64) do
-    quote(do: Protox.Decode.parse_repeated_fixed64([], unquote(bytes_var)))
+  defp make_parse_delimited(bytes_var, acc, :fixed64) do
+    quote(do: Protox.Decode.parse_repeated_fixed64(unquote(acc), unquote(bytes_var)))
   end
 
-  defp make_parse_delimited(bytes_var, :sfixed32) do
-    quote(do: Protox.Decode.parse_repeated_sfixed32([], unquote(bytes_var)))
+  defp make_parse_delimited(bytes_var, acc, :sfixed32) do
+    quote(do: Protox.Decode.parse_repeated_sfixed32(unquote(acc), unquote(bytes_var)))
   end
 
-  defp make_parse_delimited(bytes_var, :sfixed64) do
-    quote(do: Protox.Decode.parse_repeated_sfixed64([], unquote(bytes_var)))
+  defp make_parse_delimited(bytes_var, acc, :sfixed64) do
+    quote(do: Protox.Decode.parse_repeated_sfixed64(unquote(acc), unquote(bytes_var)))
   end
 
-  defp make_parse_delimited(bytes_var, :float) do
-    quote(do: Protox.Decode.parse_repeated_float([], unquote(bytes_var)))
+  defp make_parse_delimited(bytes_var, acc, :float) do
+    quote(do: Protox.Decode.parse_repeated_float(unquote(acc), unquote(bytes_var)))
   end
 
-  defp make_parse_delimited(bytes_var, :double) do
-    quote(do: Protox.Decode.parse_repeated_double([], unquote(bytes_var)))
+  defp make_parse_delimited(bytes_var, acc, :double) do
+    quote(do: Protox.Decode.parse_repeated_double(unquote(acc), unquote(bytes_var)))
   end
 
-  defp make_parse_delimited(bytes_var, {key_type, value_type}) do
+  defp make_parse_delimited(bytes_var, _acc, {key_type, value_type}) do
     unset_map_value =
       case value_type do
         {:message, msg_type} -> quote(do: struct(unquote(msg_type)))
@@ -584,7 +597,7 @@ defmodule Protox.DefineDecoder do
         {len, new_rest} = Protox.Varint.decode(unquote(vars.rest))
         {unquote(vars.delimited), delimited_rest} = Protox.Decode.parse_delimited(new_rest, len)
 
-        {unquote(make_parse_delimited(vars.delimited, type)), delimited_rest}
+        {unquote(make_parse_delimited(vars.delimited, quote(do: []), type)), delimited_rest}
       end
 
     case type do

--- a/lib/protox/define_decoder.ex
+++ b/lib/protox/define_decoder.ex
@@ -130,11 +130,12 @@ defmodule Protox.DefineDecoder do
     # at compile time, we can generate the appropriate clauses.
     # This has the benefit of a small speedup (~1%-10%) and a decrease in memory usage (~10%) from
     # the Varint.decode version.
+    #
+    # Each clause ends with the parse_key_value/2 tail call rather than returning
+    # a {msg, rest} tuple to a shared recursion point: the tuple would cost an
+    # allocation per decoded field.
     quote do
-      {msg_updated, rest} =
-        case bytes, do: unquote(all_clauses)
-
-      parse_key_value(rest, msg_updated)
+      case bytes, do: unquote(all_clauses)
     end
   end
 
@@ -177,12 +178,14 @@ defmodule Protox.DefineDecoder do
         {tag, wire_type, rest} = Protox.Decode.parse_key(unquote(vars.bytes))
         {unquote(vars.value), rest} = Protox.Decode.parse_unknown(tag, wire_type, rest)
 
-        {%{
-           unquote(vars.msg)
-           | unquote(unknown_fields_name) => [
-               unquote(vars.value) | unquote(vars.msg).unquote(unknown_fields_name)
-             ]
-         }, rest}
+        unquote(vars.msg) = %{
+          unquote(vars.msg)
+          | unquote(unknown_fields_name) => [
+              unquote(vars.value) | unquote(vars.msg).unquote(unknown_fields_name)
+            ]
+        }
+
+        parse_key_value(rest, unquote(vars.msg))
     end
   end
 
@@ -204,7 +207,8 @@ defmodule Protox.DefineDecoder do
     quote do
       <<unquote(key_bytes), unquote(vars.bytes)::binary>> ->
         {value, rest} = unquote(parse_single)
-        {unquote(update_field), rest}
+        unquote(vars.msg) = unquote(update_field)
+        parse_key_value(rest, unquote(vars.msg))
     end
   end
 
@@ -253,7 +257,8 @@ defmodule Protox.DefineDecoder do
         {len, unquote(vars.bytes)} = Protox.Varint.decode(unquote(vars.bytes))
 
         {unquote(vars.delimited), rest} = Protox.Decode.parse_delimited(unquote(vars.bytes), len)
-        {unquote(update_field), rest}
+        unquote(vars.msg) = unquote(update_field)
+        parse_key_value(rest, unquote(vars.msg))
     end
   end
 
@@ -530,26 +535,23 @@ defmodule Protox.DefineDecoder do
           # repeated MapFieldEntry map_field = N;
           #
           defp unquote(fun_name)({entry_key, entry_value}, unquote(vars.bytes)) do
-            {map_entry, unquote(vars.rest)} =
-              case unquote(vars.bytes) do
-                <<unquote(entry_key_bytes), unquote(vars.rest)::binary>> ->
-                  {res, unquote(vars.rest)} = unquote(key_parser)
-                  {{res, entry_value}, unquote(vars.rest)}
+            case unquote(vars.bytes) do
+              <<unquote(entry_key_bytes), unquote(vars.rest)::binary>> ->
+                {res, unquote(vars.rest)} = unquote(key_parser)
+                unquote(fun_name)({res, entry_value}, unquote(vars.rest))
 
-                <<unquote(entry_value_bytes), unquote(vars.rest)::binary>> ->
-                  {res, unquote(vars.rest)} = unquote(value_parser)
-                  {{entry_key, res}, unquote(vars.rest)}
+              <<unquote(entry_value_bytes), unquote(vars.rest)::binary>> ->
+                {res, unquote(vars.rest)} = unquote(value_parser)
+                unquote(fun_name)({entry_key, res}, unquote(vars.rest))
 
-                <<_unknown_entry_field::binary>> ->
-                  {tag, wire_type, unquote(vars.rest)} = Protox.Decode.parse_key(unquote(vars.bytes))
+              <<_unknown_entry_field::binary>> ->
+                {tag, wire_type, unquote(vars.rest)} = Protox.Decode.parse_key(unquote(vars.bytes))
 
-                  {_unknown_value, unquote(vars.rest)} =
-                    Protox.Decode.parse_unknown(tag, wire_type, unquote(vars.rest))
+                {_unknown_value, unquote(vars.rest)} =
+                  Protox.Decode.parse_unknown(tag, wire_type, unquote(vars.rest))
 
-                  {{entry_key, entry_value}, unquote(vars.rest)}
-              end
-
-            unquote(fun_name)(map_entry, unquote(vars.rest))
+                unquote(fun_name)({entry_key, entry_value}, unquote(vars.rest))
+            end
           end
         end
 

--- a/lib/protox/define_decoder.ex
+++ b/lib/protox/define_decoder.ex
@@ -82,16 +82,16 @@ defmodule Protox.DefineDecoder do
       |> Enum.map(& &1.name)
       |> Enum.uniq()
 
-    # Update only the fields that were actually populated: repeated fields are
-    # most often empty, and skipping them avoids both the reverse call and the
-    # struct update. The last update is the block's value, not a rebind: a
-    # final rebind would trigger an unused-variable warning in the generated
-    # code.
+    # Update only the fields that need it: repeated fields are most often empty
+    # or hold a single element (which is order-invariant), and skipping them
+    # avoids both the reverse call and the struct update. The last update is the
+    # block's value, not a rebind: a final rebind would trigger an
+    # unused-variable warning in the generated code.
     update = fn field_name ->
       quote do
         case unquote(msg_var).unquote(field_name) do
-          [] -> unquote(msg_var)
-          values -> %{unquote(msg_var) | unquote(field_name) => :lists.reverse(values)}
+          [_first, _second | _tail] = values -> %{unquote(msg_var) | unquote(field_name) => :lists.reverse(values)}
+          _empty_or_single -> unquote(msg_var)
         end
       end
     end

--- a/lib/protox/varint.ex
+++ b/lib/protox/varint.ex
@@ -4,6 +4,8 @@ defmodule Protox.Varint do
 
   import Bitwise
 
+  alias Protox.Varint.DecodeClauses
+
   @spec encode(integer) :: {binary(), non_neg_integer()}
   def encode(v) when v < 1 <<< 7, do: {<<v>>, 1}
 
@@ -78,41 +80,14 @@ defmodule Protox.Varint do
     append(<<acc::binary, 1::1, v::7>>, v >>> 7)
   end
 
+  # One unrolled clause per encoded length; the clauses are shared with the
+  # packed varint loops of Protox.Decode through Protox.Varint.DecodeClauses.
+  varint_rest = Macro.var(:rest, __MODULE__)
+
   @spec decode(binary) :: {non_neg_integer, binary}
-  def decode(<<0::1, byte0::7, rest::binary>>), do: {byte0, rest}
-
-  def decode(<<1::1, byte1::7, 0::1, byte0::7, rest::binary>>), do: {byte1 ||| byte0 <<< 7, rest}
-
-  def decode(<<1::1, byte2::7, 1::1, byte1::7, 0::1, byte0::7, rest::binary>>),
-    do: {byte2 ||| byte1 <<< 7 ||| byte0 <<< 14, rest}
-
-  def decode(<<1::1, byte3::7, 1::1, byte2::7, 1::1, byte1::7, 0::1, byte0::7, rest::binary>>),
-    do: {byte3 ||| byte2 <<< 7 ||| byte1 <<< 14 ||| byte0 <<< 21, rest}
-
-  def decode(<<1::1, byte4::7, 1::1, byte3::7, 1::1, byte2::7, 1::1, byte1::7, 0::1, byte0::7, rest::binary>>),
-    do: {byte4 ||| byte3 <<< 7 ||| byte2 <<< 14 ||| byte1 <<< 21 ||| byte0 <<< 28, rest}
-
-  def decode(
-        <<1::1, byte5::7, 1::1, byte4::7, 1::1, byte3::7, 1::1, byte2::7, 1::1, byte1::7, 0::1, byte0::7, rest::binary>>
-      ) do
-    {byte5 ||| byte4 <<< 7 ||| byte3 <<< 14 ||| byte2 <<< 21 ||| byte1 <<< 28 ||| byte0 <<< 35, rest}
+  for {pattern, value} <- DecodeClauses.build(1..8, varint_rest) do
+    def decode(unquote(pattern)), do: {unquote(value), unquote(varint_rest)}
   end
-
-  def decode(
-        <<1::1, byte6::7, 1::1, byte5::7, 1::1, byte4::7, 1::1, byte3::7, 1::1, byte2::7, 1::1, byte1::7, 0::1,
-          byte0::7, rest::binary>>
-      ),
-      do:
-        {byte6 ||| byte5 <<< 7 ||| byte4 <<< 14 ||| byte3 <<< 21 ||| byte2 <<< 28 ||| byte1 <<< 35 ||| byte0 <<< 42,
-         rest}
-
-  def decode(
-        <<1::1, byte7::7, 1::1, byte6::7, 1::1, byte5::7, 1::1, byte4::7, 1::1, byte3::7, 1::1, byte2::7, 1::1,
-          byte1::7, 0::1, byte0::7, rest::binary>>
-      ),
-      do:
-        {byte7 ||| byte6 <<< 7 ||| byte5 <<< 14 ||| byte4 <<< 21 ||| byte3 <<< 28 ||| byte2 <<< 35 ||| byte1 <<< 42 |||
-           byte0 <<< 49, rest}
 
   def decode(b), do: do_decode(0, 0, b)
 

--- a/lib/protox/varint/decode_clauses.ex
+++ b/lib/protox/varint/decode_clauses.ex
@@ -1,0 +1,49 @@
+defmodule Protox.Varint.DecodeClauses do
+  @moduledoc false
+  # Internal. Compile-time builder for unrolled LEB128-decoding clauses, shared
+  # by Protox.Varint.decode/1 and the packed varint loops of Protox.Decode so
+  # both unroll the exact same decoding. It lives outside those modules because
+  # a module cannot call its own functions from its own body.
+
+  # Imported so the quoted <<< and ||| below carry the Bitwise import with them.
+  import Bitwise
+
+  @byte_var_names ~w(b0 b1 b2 b3 b4 b5 b6 b7 b8 b9)a
+
+  # Returns one {pattern, value} pair per varint encoded length in `lengths`.
+  # `pattern` matches the varint bytes followed by `rest_var::binary`; `value`
+  # is the decoded integer. Callers splice both into their own clauses.
+  @spec build(Range.t(), Macro.t()) :: [{Macro.t(), Macro.t()}]
+  def build(lengths, rest_var) do
+    for len <- lengths do
+      byte_vars =
+        @byte_var_names
+        |> Enum.take(len)
+        |> Enum.map(&Macro.var(&1, __MODULE__))
+
+      segments =
+        byte_vars
+        |> Enum.with_index()
+        |> Enum.flat_map(fn {var, index} ->
+          [quote(do: unquote(continuation_bit(index, len)) :: 1), quote(do: unquote(var) :: 7)]
+        end)
+
+      pattern = quote(do: <<unquote_splicing(segments ++ [quote(do: unquote(rest_var) :: binary)])>>)
+
+      value =
+        byte_vars
+        |> Enum.with_index()
+        |> Enum.map(fn
+          {var, 0} -> var
+          {var, index} -> quote(do: unquote(var) <<< unquote(7 * index))
+        end)
+        |> Enum.reduce(&quote(do: unquote(&2) ||| unquote(&1)))
+
+      {pattern, value}
+    end
+  end
+
+  # The last byte of a varint has its continuation bit cleared; every other byte has it set.
+  defp continuation_bit(index, len) when index == len - 1, do: 0
+  defp continuation_bit(_index, _len), do: 1
+end

--- a/lib/protox/varint/decode_clauses.ex
+++ b/lib/protox/varint/decode_clauses.ex
@@ -1,11 +1,8 @@
 defmodule Protox.Varint.DecodeClauses do
   @moduledoc false
   # Internal. Compile-time builder for unrolled LEB128-decoding clauses, shared
-  # by Protox.Varint.decode/1 and the packed varint loops of Protox.Decode so
-  # both unroll the exact same decoding. It lives outside those modules because
-  # a module cannot call its own functions from its own body.
+  # by Protox.Varint.decode/1 and the packed varint loops of Protox.Decode.
 
-  # Imported so the quoted <<< and ||| below carry the Bitwise import with them.
   import Bitwise
 
   @byte_var_names ~w(b0 b1 b2 b3 b4 b5 b6 b7 b8 b9)a

--- a/test/protox/decode_optimizations_test.exs
+++ b/test/protox/decode_optimizations_test.exs
@@ -25,13 +25,16 @@ defmodule Protox.DecodeOptimizationsTest do
     end
   end
 
+  # parse_repeated_* prepend onto their accumulator: they return the elements in
+  # reverse wire order, and the generated finish-decode step performs the single
+  # reverse that restores wire order.
   describe "packed fixed-width fast path" do
     test "decodes element counts around the four-element unroll boundary" do
       for count <- 1..9 do
         values = Enum.to_list(1..count)
         bytes = for v <- values, into: <<>>, do: <<v::unsigned-little-32>>
 
-        assert Protox.Decode.parse_repeated_fixed32([], bytes) == values
+        assert Protox.Decode.parse_repeated_fixed32([], bytes) == Enum.reverse(values)
       end
     end
 
@@ -40,7 +43,7 @@ defmodule Protox.DecodeOptimizationsTest do
 
       bytes = Protox.Encode.encode_packed_double(values, <<>>)
 
-      assert Protox.Decode.parse_repeated_double([], bytes) == values
+      assert Protox.Decode.parse_repeated_double([], bytes) == Enum.reverse(values)
     end
 
     test "raises on a truncated packed fixed32 payload" do

--- a/test/protox/decode_test.exs
+++ b/test/protox/decode_test.exs
@@ -60,6 +60,11 @@ defmodule Protox.DecodeTest do
       %TestAllTypesProto3{repeated_uint32: [0, 1, 2, 3, 10_000]}
     },
     {
+      "Repeated uint32, two multi-element packed runs, should be concatenated in wire order",
+      <<138, 2, 3, 1, 2, 3>> <> <<138, 2, 3, 4, 5, 6>>,
+      %TestAllTypesProto3{repeated_uint32: [1, 2, 3, 4, 5, 6]}
+    },
+    {
       "Repeated sint32",
       <<154, 2, 7, 0, 1, 4, 5, 160, 156, 1>>,
       %TestAllTypesProto3{repeated_sint32: [0, -1, 2, -3, 10_000]}

--- a/test/protox/packed_encode_test.exs
+++ b/test/protox/packed_encode_test.exs
@@ -79,13 +79,15 @@ defmodule Protox.PackedEncodeTest do
     test "float/double: special values interleaved with finite ones" do
       values = [1.5, :infinity, :"-infinity", :nan, -2.5]
 
+      # parse_repeated_* return the elements in reverse wire order (the generated
+      # finish-decode step performs the single restoring reverse).
       packed_double = Encode.encode_packed_double(values, <<>>)
       assert byte_size(packed_double) == 5 * 8
-      assert Protox.Decode.parse_repeated_double([], packed_double) == values
+      assert Protox.Decode.parse_repeated_double([], packed_double) == Enum.reverse(values)
 
       packed_float = Encode.encode_packed_float(values, <<>>)
       assert byte_size(packed_float) == 5 * 4
-      assert Protox.Decode.parse_repeated_float([], packed_float) == values
+      assert Protox.Decode.parse_repeated_float([], packed_float) == Enum.reverse(values)
     end
 
     test "bool and enum" do


### PR DESCRIPTION
## Summary

A five-commit series cutting the decoder's allocations, motivated by a head-to-head benchmark against elixir-protobuf showing protox decodes faster but allocates ~2× the memory — enough GC pressure to lose on wall time for large messages. Each commit was measured independently with `mix protox.benchmark.run --task decode` (reductions + memory medians as decision metrics).

1. **Tail-call the decode loop from each generated clause** — removes a `{msg, rest}` tuple and a materialized `rest` sub-binary per decoded field.
2. **Seed packed decode with the field's list and reverse once** — packed runs drop from 4N to 2N cons cells. This changes the generated-code ↔ runtime contract of `parse_repeated_*`, so the generator version is bumped to 3. A new regression test pins two-packed-runs concatenation order.
3. **Skip the finish-decode reverse for empty and single-element lists** — both are order-invariant; skipping saves the reverse and a full struct copy.
4. **Unroll varint decoding inside the packed varint loops** — one clause per encoded length (all 10 — covering fewer lets valid varints fall through and convert the match context back to a sub-binary per element). The clause set is built by the new `Protox.Varint.DecodeClauses`, which also regenerates `Protox.Varint.decode/1`, so both decoders share one LEB128 unrolling.
5. **Decode one-byte varint scalars in the generated key clause** — fast-path clause matching the value in the key pattern; larger values fall through to the general clause. Delimited fields deliberately get no such clause: a dynamic `binary-size(len)` segment defeats the shared match tree of the generated `case` (measured at +410% memory on the 200-field synthetic input).

## Cumulative decode results (benchmark corpus, vs 9cf9bbd)

Both decision metrics improve on all 17 inputs.

| Input | Δ reductions | Δ memory | Δ ips |
|---|---|---|---|
| edge_negative_varints | −93% | −80% | +77% |
| test_all_types_proto3 | −26% | −12% | +30% |
| google_message1 (proto2/proto3) | −17…−23% | −20% | +15% |
| synthetic_5…200 | −8…−22% | −9…−22% | +15…+25% |
| prometheus_write_request | −11% | −14% | +10% |
| otel_traces_data | −4% | −8% | +17% |
| ascii / maps / edge_* | −0.2…−1.4% | −4…−15% | +3…+16% |

Reductions/memory medians reproduced bit-for-bit across a confirming double run. Encode is unaffected (memory bit-identical, reductions within rebuild jitter).

## Test plan

- `mix test` (235 passing, incl. a new regression test for two packed runs of the same field)
- `mix credo` / `mix dialyzer` clean
- Conformance: relies on this PR's CI run (local runner doesn't build on macOS)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved decoding speed for variable-length integers and packed repeated fields.
  * Streamlined message, map, and unknown-field decoding.

* **Bug Fixes**
  * Preserved wire order when combining multiple packed repeated-field segments.
  * Improved handling of repeated numeric values during decoding and finalization.

* **Tests**
  * Added coverage for multi-segment packed fields.
  * Updated repeated numeric-field expectations to reflect corrected decoding behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->









<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR reduces decoder allocations by tail-calling generated decode clauses, accumulating packed values in reverse order until finalization, and unrolling common varint paths.
- Adds shared compile-time generation for unrolled LEB128 decoding clauses.
- Adds one-byte scalar-varint fast paths to generated decoders.
- Updates repeated-field finalization and tests for packed-run ordering.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because no eligible blocking failure remains in the provided follow-up-review scope.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| lib/protox/decode.ex | Changes packed repeated decoders to maintain reversed accumulators and adds unrolled varint clauses. |
| lib/protox/define_decoder.ex | Tail-calls generated decode branches, seeds packed accumulators from message state, and adds one-byte scalar fast paths. |
| lib/protox/varint.ex | Replaces handwritten short-varint clauses with clauses produced by the shared builder. |
| lib/protox/varint/decode_clauses.ex | Introduces the compile-time builder shared by scalar and packed varint decoding. |
| test/protox/decode_test.exs | Adds regression coverage proving multiple packed runs retain wire order. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[Encoded message bytes] --> B[Generated key clause]
  B --> C{One-byte varint?}
  C -->|Yes| D[Inline scalar decode]
  C -->|No| E[General value decoder]
  B --> F[Packed field]
  F --> G[Seed reversed field accumulator]
  G --> H[Unrolled repeated-value decoder]
  D --> I[Update message]
  E --> I
  H --> I
  I --> J{Bytes remain?}
  J -->|Yes| B
  J -->|No| K[Reverse multi-element repeated fields]
  K --> L[Decoded message]
```
</details>

<sub>Reviews (5): Last reviewed commit: ["refactor: split the one-byte varint fast..."](https://github.com/ahamez/protox/commit/5f698852402de662a8e73145fd27715f290c068e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57878918)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Knowledge Base — [Protocol Buffers decoding](https://app.greptile.com/ahamez/-/custom-context/knowledge-base/ahamez/protox/-/docs/protobuf-decoding.md)
- Knowledge Base — [Wire-format primitives](https://app.greptile.com/ahamez/-/custom-context/knowledge-base/ahamez/protox/-/docs/wire-format-primitives.md)
- Knowledge Base — [Message declaration macros](https://app.greptile.com/ahamez/-/custom-context/knowledge-base/ahamez/protox/-/docs/message-declaration-macros.md)
</details>


<!-- /greptile_comment -->